### PR TITLE
Use byte buffer as output type

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ The `OggOpusDecoder` is a portable C++ wrapper that works on any platform, not j
 // Create decoder
 micro_opus::OggOpusDecoder decoder;
 
-// Allocate output buffer
+// Allocate output buffer (int16_t for 16-bit PCM samples)
 int16_t pcm_buffer[960 * 2];  // 20ms @ 48kHz stereo
 
 // Decode loop
@@ -154,12 +154,12 @@ while (have_input_data) {
 
     micro_opus::OggOpusResult result = decoder.decode(
         input_ptr, input_len,
-        pcm_buffer, sizeof(pcm_buffer),
+        reinterpret_cast<uint8_t*>(pcm_buffer), sizeof(pcm_buffer),
         bytes_consumed, samples_decoded
     );
 
     if (result == micro_opus::OGG_OPUS_OK && samples_decoded > 0) {
-        // Process decoded PCM samples
+        // Process decoded PCM samples (int16_t)
         // Send to I2S DAC, save to file, etc.
     }
 

--- a/examples/decode_benchmark/src/decode_benchmark.cpp
+++ b/examples/decode_benchmark/src/decode_benchmark.cpp
@@ -162,9 +162,9 @@ static DecodeResult decode_full_file(const uint8_t* audio_data, size_t audio_siz
         // Time this decode call
         int64_t frame_start = esp_timer_get_time();
 
-        micro_opus::OggOpusResult decode_result =
-            decoder.decode(input_ptr, input_remaining, pcm_buffer.data(),
-                           pcm_buffer.size() * sizeof(int16_t), bytes_consumed, samples_decoded);
+        micro_opus::OggOpusResult decode_result = decoder.decode(
+            input_ptr, input_remaining, reinterpret_cast<uint8_t*>(pcm_buffer.data()),
+            pcm_buffer.size() * sizeof(int16_t), bytes_consumed, samples_decoded);
 
         int64_t frame_time = esp_timer_get_time() - frame_start;
 

--- a/host_examples/opus_to_wav/opus_to_wav.cpp
+++ b/host_examples/opus_to_wav/opus_to_wav.cpp
@@ -103,9 +103,10 @@ int main(int argc, char* argv[]) {
 
                 decode_calls++;
 
-                micro_opus::OggOpusResult result = decoder.decode(
-                    input_buffer.data() + chunk_offset, bytes_read - chunk_offset,
-                    pcm_buffer.data(), pcm_buffer.size() * sizeof(int16_t), consumed, samples);
+                micro_opus::OggOpusResult result =
+                    decoder.decode(input_buffer.data() + chunk_offset, bytes_read - chunk_offset,
+                                   reinterpret_cast<uint8_t*>(pcm_buffer.data()),
+                                   pcm_buffer.size() * sizeof(int16_t), consumed, samples);
 
                 total_bytes_consumed += consumed;
                 chunk_offset += consumed;

--- a/host_examples/opus_to_wav/test/measure_zerocopy.cpp
+++ b/host_examples/opus_to_wav/test/measure_zerocopy.cpp
@@ -52,9 +52,9 @@ int main(int argc, char* argv[]) {
                 size_t consumed = 0;
                 size_t samples = 0;
 
-                micro_opus::OggOpusResult result =
-                    decoder.decode(input_buffer.data(), offset, pcm_buffer.data(),
-                                   pcm_buffer.size() * sizeof(int16_t), consumed, samples);
+                micro_opus::OggOpusResult result = decoder.decode(
+                    input_buffer.data(), offset, reinterpret_cast<uint8_t*>(pcm_buffer.data()),
+                    pcm_buffer.size() * sizeof(int16_t), consumed, samples);
 
                 if (result < 0 && consumed == 0) {
                     // Real error (not just need-more-data)

--- a/host_examples/opus_to_wav/test/test_chunked.cpp
+++ b/host_examples/opus_to_wav/test/test_chunked.cpp
@@ -82,9 +82,9 @@ int main(int argc, char* argv[]) {
                 size_t samples = 0;
 
                 decode_calls++;
-                micro_opus::OggOpusResult result =
-                    decoder.decode(input_buffer.data(), buffer_used, pcm_buffer.data(),
-                                   pcm_buffer.size() * sizeof(int16_t), consumed, samples);
+                micro_opus::OggOpusResult result = decoder.decode(
+                    input_buffer.data(), buffer_used, reinterpret_cast<uint8_t*>(pcm_buffer.data()),
+                    pcm_buffer.size() * sizeof(int16_t), consumed, samples);
 
                 if (decode_calls < VERBOSE_DECODE_THRESHOLD ||
                     decode_calls % PROGRESS_INTERVAL == 0) {

--- a/host_examples/opus_to_wav/test/test_silent_channels.cpp
+++ b/host_examples/opus_to_wav/test/test_silent_channels.cpp
@@ -282,9 +282,9 @@ int main() {
     printf("Decoding stream...\n");
 
     while (total_consumed < stream.size()) {
-        micro_opus::OggOpusResult result =
-            decoder.decode(stream.data() + total_consumed, stream.size() - total_consumed,
-                           pcm_buffer, sizeof(pcm_buffer), consumed, samples_decoded);
+        micro_opus::OggOpusResult result = decoder.decode(
+            stream.data() + total_consumed, stream.size() - total_consumed,
+            reinterpret_cast<uint8_t*>(pcm_buffer), sizeof(pcm_buffer), consumed, samples_decoded);
 
         total_consumed += consumed;
 

--- a/include/micro_opus/ogg_opus_decoder.h
+++ b/include/micro_opus/ogg_opus_decoder.h
@@ -118,7 +118,7 @@ enum OggOpusResult : int8_t {
  *     size_t consumed, samples;
  *     OggOpusResult result = decoder.decode(
  *         input_ptr, input_len,
- *         pcm_buffer, sizeof(pcm_buffer),
+ *         reinterpret_cast<uint8_t*>(pcm_buffer), sizeof(pcm_buffer),
  *         consumed, samples
  *     );
  *
@@ -182,7 +182,9 @@ public:
      *
      * @param input Pointer to input Ogg Opus data (must not be nullptr)
      * @param input_len Number of bytes available in input
-     * @param output Pointer to output buffer for PCM samples (must not be nullptr)
+     * @param output Pointer to output buffer for PCM samples (must not be nullptr).
+     *               The buffer should be aligned for int16_t access. Currently outputs
+     *               16-bit signed PCM samples (int16_t).
      * @param output_size Number of bytes available in output buffer
      * @param bytes_consumed [OUT] Number of input bytes consumed (may be buffered internally)
      * @param samples_decoded [OUT] Number of PCM samples decoded (per channel)
@@ -211,7 +213,7 @@ public:
      * @note Can handle arbitrarily small input chunks (even 1 byte at a time)
      *       thanks to internal header staging buffer.
      */
-    OggOpusResult decode(const uint8_t* input, size_t input_len, int16_t* output,
+    OggOpusResult decode(const uint8_t* input, size_t input_len, uint8_t* output,
                          size_t output_size, size_t& bytes_consumed, size_t& samples_decoded);
 
     /**
@@ -341,7 +343,7 @@ private:
     OggOpusDecoder& operator=(const OggOpusDecoder&) = delete;
 
     // Internal packet processing
-    OggOpusResult process_packet(const micro_ogg::OggPacket& packet, int16_t* output,
+    OggOpusResult process_packet(const micro_ogg::OggPacket& packet, uint8_t* output,
                                  size_t output_size, size_t& samples_decoded);
 
     // Page boundary tracking helper
@@ -352,7 +354,7 @@ private:
                                             bool is_eos, bool is_last_on_page);
 
     // Pre-skip handling helper
-    OggOpusResult apply_pre_skip(int16_t* output, size_t decoded_samples, uint8_t output_channels,
+    OggOpusResult apply_pre_skip(uint8_t* output, size_t decoded_samples, uint8_t output_channels,
                                  size_t& samples_decoded);
 
     // Opus decoder creation helper
@@ -365,7 +367,7 @@ private:
                                           int64_t granule_pos, bool is_last_on_page);
     OggOpusResult handle_audio_packet(const uint8_t* packet_data, size_t packet_len,
                                       int64_t granule_pos, bool is_eos, bool is_last_on_page,
-                                      int16_t* output, size_t output_size, size_t& samples_decoded);
+                                      uint8_t* output, size_t output_size, size_t& samples_decoded);
 
     // Internal state machine
     enum State : uint8_t { STATE_EXPECT_OPUS_HEAD, STATE_EXPECT_OPUS_TAGS, STATE_DECODING };


### PR DESCRIPTION
Breaking change to use a ``uint8_t`` pointer for the output type. This is to future proof for supporting 24 bits per sample (introduced in opus v1.6.0).