### PR TITLE
Fix release drafter and remove trailing comma to make the manifest valid

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Update version files
         run: |
           sed -i "s/\"version\": .*/\"version\": \"${{ steps.drafter.outputs.resolved_version }}\",/g" library.json
-          sed -i "s/version: .*/version: \"${{ steps.drafter.outputs.resolved_version }}\",/g" idf_component.yml
+          sed -i "s/version: .*/version: \"${{ steps.drafter.outputs.resolved_version }}\"/g" idf_component.yml
 
       - name: Commit changes
         run: |

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -6,4 +6,4 @@ description: "Opus audio codec library for ESP32 - high-quality audio compressio
 license: "Apache-2.0"
 maintainers:
   - Kevin Ahrendt <kevin.ahrendt@openhomefoundation.org>
-version: "0.3.1",
+version: "0.3.1"


### PR DESCRIPTION
The previous release-drafter was inserting a comma in the yaml manifest for the IDF component, causing PlatformIO problems when trying to build the encode_benchmark