### PR TITLE
Fix Espressif component registry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ endif()
 # Include CMake modules
 # ==============================================================================
 
+include(${OPUS_COMPONENT_DIR}/cmake/dependencies.cmake)
 include(${OPUS_COMPONENT_DIR}/cmake/sources.cmake)
 include(${OPUS_COMPONENT_DIR}/cmake/functions.cmake)
 include(${OPUS_COMPONENT_DIR}/cmake/staging.cmake)

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -1,0 +1,56 @@
+# cmake/dependencies.cmake
+# Dependency resolution for microOpus
+#
+# When used as an ESP-IDF managed component, git submodules are not available.
+# This module uses FetchContent to download dependencies when the submodule
+# directories don't exist.
+
+# Guard against multiple inclusion
+if(__opus_dependencies_defined)
+    return()
+endif()
+set(__opus_dependencies_defined TRUE)
+
+include(FetchContent)
+
+# Pinned dependency versions (must match .gitmodules)
+set(OPUS_VERSION "v1.6.1")
+set(MICRO_OGG_DEMUXER_VERSION "v1.1.0")
+
+# ==============================================================================
+# Resolve opus library source directory
+# ==============================================================================
+set(OPUS_LIB_DIR "${OPUS_COMPONENT_DIR}/lib/opus")
+
+if(NOT EXISTS "${OPUS_LIB_DIR}/include/opus.h")
+    message(STATUS "micro-opus: lib/opus submodule not found, fetching opus ${OPUS_VERSION}...")
+    FetchContent_Declare(
+        opus_source
+        URL "https://github.com/xiph/opus/archive/refs/tags/${OPUS_VERSION}.tar.gz"
+    )
+    FetchContent_GetProperties(opus_source)
+    if(NOT opus_source_POPULATED)
+        FetchContent_Populate(opus_source)
+    endif()
+    set(OPUS_LIB_DIR "${opus_source_SOURCE_DIR}")
+    message(STATUS "micro-opus: Fetched opus to ${OPUS_LIB_DIR}")
+endif()
+
+# ==============================================================================
+# Resolve micro-ogg-demuxer source directory
+# ==============================================================================
+set(MICRO_OGG_LIB_DIR "${OPUS_COMPONENT_DIR}/lib/micro-ogg-demuxer")
+
+if(NOT EXISTS "${MICRO_OGG_LIB_DIR}/CMakeLists.txt")
+    message(STATUS "micro-opus: lib/micro-ogg-demuxer submodule not found, fetching ${MICRO_OGG_DEMUXER_VERSION}...")
+    FetchContent_Declare(
+        micro_ogg_source
+        URL "https://github.com/esphome-libs/micro-ogg-demuxer/archive/refs/tags/${MICRO_OGG_DEMUXER_VERSION}.tar.gz"
+    )
+    FetchContent_GetProperties(micro_ogg_source)
+    if(NOT micro_ogg_source_POPULATED)
+        FetchContent_Populate(micro_ogg_source)
+    endif()
+    set(MICRO_OGG_LIB_DIR "${micro_ogg_source_SOURCE_DIR}")
+    message(STATUS "micro-opus: Fetched micro-ogg-demuxer to ${MICRO_OGG_LIB_DIR}")
+endif()

--- a/cmake/esp-idf.cmake
+++ b/cmake/esp-idf.cmake
@@ -32,8 +32,9 @@ function(opus_configure_esp_idf COMPONENT_LIB COMPONENT_DIR OPUS_STAGED_DIR)
     endif()
 
     # Add micro-ogg-demuxer as a subdirectory
+    # Uses MICRO_OGG_LIB_DIR from dependencies.cmake (handles submodule vs FetchContent)
     if(NOT TARGET micro_ogg_demuxer)
-        add_subdirectory(${COMPONENT_DIR}/lib/micro-ogg-demuxer
+        add_subdirectory(${MICRO_OGG_LIB_DIR}
                          ${CMAKE_CURRENT_BINARY_DIR}/micro-ogg-demuxer)
     endif()
     target_link_libraries(${COMPONENT_LIB} PUBLIC micro_ogg_demuxer)

--- a/cmake/host.cmake
+++ b/cmake/host.cmake
@@ -21,8 +21,9 @@ set(__opus_host_defined TRUE)
 # ==============================================================================
 function(opus_configure_host TARGET SOURCE_DIR OPUS_STAGED_DIR)
     # Add micro-ogg-demuxer as a subdirectory
+    # Uses MICRO_OGG_LIB_DIR from dependencies.cmake (handles submodule vs FetchContent)
     if(NOT TARGET micro_ogg_demuxer)
-        add_subdirectory(${SOURCE_DIR}/lib/micro-ogg-demuxer
+        add_subdirectory(${MICRO_OGG_LIB_DIR}
                          ${CMAKE_CURRENT_BINARY_DIR}/micro-ogg-demuxer)
     endif()
     target_link_libraries(${TARGET} PUBLIC micro_ogg_demuxer)

--- a/cmake/staging.cmake
+++ b/cmake/staging.cmake
@@ -240,7 +240,8 @@ endfunction()
 #   OPUS_STAGED_DIR - Path to the staged opus directory (for use in include paths)
 # ==============================================================================
 function(opus_setup_staged_build COMPONENT_DIR APPLY_XTENSA)
-    set(SOURCE_DIR "${COMPONENT_DIR}/lib/opus")
+    # Use OPUS_LIB_DIR from dependencies.cmake (handles submodule vs FetchContent)
+    set(SOURCE_DIR "${OPUS_LIB_DIR}")
     set(STAGED_DIR "${CMAKE_CURRENT_BINARY_DIR}/opus-staged")
 
     # Create staging directory


### PR DESCRIPTION
The Espressif component registry code doesn't include submodules, so add a fallback to fetch the content at build time.