### PR TITLE
Don't fail builds on -Wmaybe-uninitialized false positive (GCC 14+)

### DIFF
--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -40,5 +40,11 @@ function(opus_set_optimization_flags TARGET)
         -O2
         -ffunction-sections
         -fdata-sections
+        # GCC 14+ emits a false-positive -Wmaybe-uninitialized in upstream
+        # silk/NLSF2A.c: cos_LSF_QA[] is filled via a permutation table the
+        # analyzer can't reason about. Demote to a non-fatal warning so
+        # consumers building with -Werror=all (e.g. ESP-IDF defaults) don't
+        # break. Remove once upstream xiph/opus silences this.
+        -Wno-error=maybe-uninitialized
     )
 endfunction()


### PR DESCRIPTION
## Summary
- Adds `-Wno-error=maybe-uninitialized` to the common Opus build flags so a GCC 14+ false positive in upstream `silk/NLSF2A.c` doesn't fail builds where the parent project uses `-Werror=all`.

## Context
On the xtensa-esp-elf 14.2.0 toolchain (latest ESP-IDF default), compiling upstream Opus's `silk/NLSF2A.c` aborts with:

```
silk/NLSF2A.c:54:19: error: 'cos_LSF_QA' may be used uninitialized [-Werror=maybe-uninitialized]
   54 |     out[1] = -cLSF[0];
note: in 'silk_NLSF2A_find_poly', inlined from 'silk_NLSF2A' at silk/NLSF2A.c:116:5
note: 'cos_LSF_QA' declared here
   83 |     opus_int32 cos_LSF_QA[ SILK_MAX_ORDER_LPC ];
```

The diagnostic is a false positive: `cos_LSF_QA[ordering[k]]` is written for `k` in `0..d-1`, where `ordering` is a fixed permutation of `0..d-1` (`ordering10` / `ordering16`). The compiler can't reason about the permutation table, so when `silk_NLSF2A_find_poly` is inlined at line 116 it sees `cLSF[0]` as potentially uninitialized.

It only surfaces now because ESPHome's new native-IDF build path (esphome/esphome#14678) exposes more managed components to ESP-IDF's `-Werror=all` defaults under GCC 14.

## Approach
Demote (not silence) the warning via `-Wno-error=maybe-uninitialized`. The warning is still emitted, so we'll notice if upstream xiph/opus ever fixes it and can drop the workaround. The flag is added in `opus_set_optimization_flags`, which is shared by both ESP-IDF and host builds.

## Test plan
- [ ] ESP-IDF build via `esphome/esphome#14678` CI completes the failing `Test components batch () with native ESP-IDF` job
- [ ] Host build still compiles cleanly
- [ ] No new warnings introduced for older GCC (flag is a no-op there)