### PR TITLE
Add Opus packet decoder

### DIFF
--- a/cmake/sources.cmake
+++ b/cmake/sources.cmake
@@ -239,10 +239,11 @@ endfunction()
 # Non-opus sources (these don't depend on OPUS_DIR)
 # ==============================================================================
 
-# Ogg Opus decoder (C++ wrapper) - in our src/ directory
+# Opus decoder C++ wrappers - in our src/ directory
 set(OGG_OPUS_SOURCES
     src/opus_header.cpp
     src/ogg_opus_decoder.cpp
+    src/opus_packet_decoder.cpp
 )
 
 # Thread-local storage sources (for THREADSAFE_PSEUDOSTACK mode)

--- a/host_examples/opus_to_wav/CMakeLists.txt
+++ b/host_examples/opus_to_wav/CMakeLists.txt
@@ -46,6 +46,9 @@ target_link_libraries(test_chunked PRIVATE micro_opus)
 add_executable(test_silent_channels test/test_silent_channels.cpp)
 target_link_libraries(test_silent_channels PRIVATE micro_opus)
 
+add_executable(test_raw_packet test/test_raw_packet.cpp)
+target_link_libraries(test_raw_packet PRIVATE micro_opus)
+
 # Benchmark tool (requires debug/stats enabled)
 add_executable(measure_zerocopy test/measure_zerocopy.cpp)
 target_link_libraries(measure_zerocopy PRIVATE micro_opus)

--- a/host_examples/opus_to_wav/test/test_raw_packet.cpp
+++ b/host_examples/opus_to_wav/test/test_raw_packet.cpp
@@ -1,0 +1,168 @@
+// Copyright 2026 Kevin Ahrendt
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Round-trip test for OpusPacketDecoder: encode sine-wave frames with libopus, then decode the
+// raw packets (no Ogg container) and verify output sizing, buffer-too-small recovery, packet-loss
+// concealment, and reset(). Build with -DENABLE_SANITIZERS=ON to catch memory errors.
+
+#include "micro_opus/opus_packet_decoder.h"
+#include "opus.h"
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+namespace {
+
+constexpr uint32_t kSampleRate = 48000;
+constexpr uint8_t kChannels = 2;
+constexpr int kFrameSamples = 960;  // 20 ms at 48 kHz, per channel
+constexpr size_t kFrameBytes = static_cast<size_t>(kFrameSamples) * kChannels * sizeof(int16_t);
+
+int g_failures = 0;
+
+void check(bool condition, const char* message) {
+    if (!condition) {
+        std::printf("  FAIL: %s\n", message);
+        ++g_failures;
+    }
+}
+
+// Fill one interleaved stereo frame with a sine wave so the encoder has real signal to work with.
+void fill_sine_frame(std::vector<int16_t>& pcm, double& phase) {
+    pcm.resize(static_cast<size_t>(kFrameSamples) * kChannels);
+    const double step = 2.0 * 3.14159265358979323846 * 440.0 / kSampleRate;
+    for (int i = 0; i < kFrameSamples; ++i) {
+        int16_t sample = static_cast<int16_t>(std::lround(std::sin(phase) * 12000.0));
+        pcm[static_cast<size_t>(i) * kChannels + 0] = sample;
+        pcm[static_cast<size_t>(i) * kChannels + 1] = sample;
+        phase += step;
+    }
+}
+
+}  // namespace
+
+int main() {
+    std::printf("OpusPacketDecoder round-trip test\n");
+
+    // --- Encode a handful of frames into raw Opus packets ---
+    int enc_error = 0;
+    OpusEncoder* encoder =
+        opus_encoder_create(kSampleRate, kChannels, OPUS_APPLICATION_AUDIO, &enc_error);
+    if (encoder == nullptr || enc_error != OPUS_OK) {
+        std::printf("  FAIL: could not create encoder (%d)\n", enc_error);
+        return 1;
+    }
+
+    constexpr int kNumFrames = 10;
+    std::vector<std::vector<uint8_t>> packets;
+    std::vector<int16_t> pcm;
+    double phase = 0.0;
+    for (int f = 0; f < kNumFrames; ++f) {
+        fill_sine_frame(pcm, phase);
+        std::vector<uint8_t> packet(4000);
+        int bytes = opus_encode(encoder, pcm.data(), kFrameSamples, packet.data(),
+                                static_cast<opus_int32>(packet.size()));
+        if (bytes < 0) {
+            std::printf("  FAIL: opus_encode returned %d\n", bytes);
+            opus_encoder_destroy(encoder);
+            return 1;
+        }
+        packet.resize(static_cast<size_t>(bytes));
+        packets.push_back(std::move(packet));
+    }
+    opus_encoder_destroy(encoder);
+
+    // --- Decode the packets and verify ---
+    micro_opus::OpusPacketDecoder decoder(kSampleRate, kChannels);
+
+    // PcmFormat is valid immediately (pre-framed: format comes from the constructor).
+    const auto& fmt = decoder.get_pcm_format();
+    check(fmt.is_valid(), "format valid before first decode");
+    check(fmt.sample_rate() == kSampleRate, "format sample_rate");
+    check(fmt.num_channels() == kChannels, "format num_channels");
+    check(fmt.bytes_per_sample() == 2, "format bytes_per_sample");
+    // max_output_bytes is the 120 ms upper bound: 48000/1000*120 = 5760 samples/ch.
+    check(fmt.max_output_bytes() == 5760u * kChannels * 2u, "format max_output_bytes");
+
+    std::vector<uint8_t> out(fmt.max_output_bytes());
+    for (size_t i = 0; i < packets.size(); ++i) {
+        size_t bytes_written = 0;
+        auto result = decoder.decode(packets[i].data(), packets[i].size(), out.data(), out.size(),
+                                     bytes_written);
+        check(result == micro_opus::OPUS_PACKET_DECODER_SUCCESS, "decode succeeds");
+        check(bytes_written == kFrameBytes, "decode bytes_written == one 20 ms stereo frame");
+    }
+
+    // --- Recoverable OUTPUT_BUFFER_TOO_SMALL: tiny buffer, then grow and retry ---
+    {
+        size_t bytes_written = 12345;
+        std::vector<uint8_t> tiny(16);
+        auto result = decoder.decode(packets[0].data(), packets[0].size(), tiny.data(), tiny.size(),
+                                     bytes_written);
+        check(result == micro_opus::OPUS_PACKET_DECODER_ERROR_OUTPUT_BUFFER_TOO_SMALL,
+              "small buffer => OUTPUT_BUFFER_TOO_SMALL");
+        check(bytes_written == 0, "failed decode clears bytes_written");
+        size_t needed = decoder.get_required_output_bytes();
+        check(needed == kFrameBytes, "get_required_output_bytes reports exact size");
+
+        std::vector<uint8_t> grown(needed);
+        result = decoder.decode(packets[0].data(), packets[0].size(), grown.data(), grown.size(),
+                                bytes_written);
+        check(result == micro_opus::OPUS_PACKET_DECODER_SUCCESS, "retry after grow succeeds");
+        check(bytes_written == kFrameBytes, "retry produces full frame");
+    }
+
+    // --- Packet-loss concealment ---
+    {
+        size_t bytes_written = 0;
+        auto result = decoder.conceal_loss(out.data(), out.size(), kFrameSamples, bytes_written);
+        check(result == micro_opus::OPUS_PACKET_DECODER_SUCCESS, "conceal_loss succeeds");
+        check(bytes_written == kFrameBytes, "conceal_loss fills one frame");
+    }
+
+    // --- Invalid arguments ---
+    {
+        size_t bytes_written = 7;
+        auto null_input = decoder.decode(nullptr, 10, out.data(), out.size(), bytes_written);
+        check(null_input == micro_opus::OPUS_PACKET_DECODER_ERROR_INPUT_INVALID,
+              "null input => INPUT_INVALID");
+        check(bytes_written == 0, "invalid call clears bytes_written");
+
+        auto empty_input =
+            decoder.decode(packets[0].data(), 0, out.data(), out.size(), bytes_written);
+        check(empty_input == micro_opus::OPUS_PACKET_DECODER_ERROR_INPUT_INVALID,
+              "empty input => INPUT_INVALID");
+    }
+
+    // --- reset() preserves config and keeps decoding ---
+    {
+        decoder.reset();
+        check(decoder.get_required_output_bytes() == 0, "reset clears required_output_bytes");
+        check(decoder.get_pcm_format().sample_rate() == kSampleRate, "reset preserves config");
+        size_t bytes_written = 0;
+        auto result = decoder.decode(packets[0].data(), packets[0].size(), out.data(), out.size(),
+                                     bytes_written);
+        check(result == micro_opus::OPUS_PACKET_DECODER_SUCCESS, "decode works after reset");
+        check(bytes_written == kFrameBytes, "post-reset frame size");
+    }
+
+    if (g_failures == 0) {
+        std::printf("PASS: all checks passed\n");
+        return 0;
+    }
+    std::printf("FAILED: %d check(s)\n", g_failures);
+    return 1;
+}

--- a/host_examples/opus_to_wav/test/test_raw_packet.cpp
+++ b/host_examples/opus_to_wav/test/test_raw_packet.cpp
@@ -97,11 +97,14 @@ int main() {
     // max_output_bytes is the 120 ms upper bound: 48000/1000*120 = 5760 samples/ch.
     check(fmt.max_output_bytes() == 5760u * kChannels * 2u, "format max_output_bytes");
 
-    std::vector<uint8_t> out(fmt.max_output_bytes());
+    // int16_t output buffer: naturally aligned for the decoder's 16-bit PCM writes. The API stays
+    // byte-oriented, so cast to uint8_t* and pass the size in bytes at each call site.
+    std::vector<int16_t> out(fmt.max_output_bytes() / sizeof(int16_t));
     for (size_t i = 0; i < packets.size(); ++i) {
         size_t bytes_written = 0;
-        auto result = decoder.decode(packets[i].data(), packets[i].size(), out.data(), out.size(),
-                                     bytes_written);
+        auto result = decoder.decode(packets[i].data(), packets[i].size(),
+                                     reinterpret_cast<uint8_t*>(out.data()),
+                                     out.size() * sizeof(int16_t), bytes_written);
         check(result == micro_opus::OPUS_PACKET_DECODER_SUCCESS, "decode succeeds");
         check(bytes_written == kFrameBytes, "decode bytes_written == one 20 ms stereo frame");
     }
@@ -109,18 +112,20 @@ int main() {
     // --- Recoverable OUTPUT_BUFFER_TOO_SMALL: tiny buffer, then grow and retry ---
     {
         size_t bytes_written = 12345;
-        std::vector<uint8_t> tiny(16);
-        auto result = decoder.decode(packets[0].data(), packets[0].size(), tiny.data(), tiny.size(),
-                                     bytes_written);
+        std::vector<int16_t> tiny(8);  // 16 bytes: far too small for one frame
+        auto result = decoder.decode(packets[0].data(), packets[0].size(),
+                                     reinterpret_cast<uint8_t*>(tiny.data()),
+                                     tiny.size() * sizeof(int16_t), bytes_written);
         check(result == micro_opus::OPUS_PACKET_DECODER_ERROR_OUTPUT_BUFFER_TOO_SMALL,
               "small buffer => OUTPUT_BUFFER_TOO_SMALL");
         check(bytes_written == 0, "failed decode clears bytes_written");
         size_t needed = decoder.get_required_output_bytes();
         check(needed == kFrameBytes, "get_required_output_bytes reports exact size");
 
-        std::vector<uint8_t> grown(needed);
-        result = decoder.decode(packets[0].data(), packets[0].size(), grown.data(), grown.size(),
-                                bytes_written);
+        std::vector<int16_t> grown(needed / sizeof(int16_t));
+        result = decoder.decode(packets[0].data(), packets[0].size(),
+                                reinterpret_cast<uint8_t*>(grown.data()),
+                                grown.size() * sizeof(int16_t), bytes_written);
         check(result == micro_opus::OPUS_PACKET_DECODER_SUCCESS, "retry after grow succeeds");
         check(bytes_written == kFrameBytes, "retry produces full frame");
     }
@@ -128,7 +133,9 @@ int main() {
     // --- Packet-loss concealment ---
     {
         size_t bytes_written = 0;
-        auto result = decoder.conceal_loss(out.data(), out.size(), kFrameSamples, bytes_written);
+        auto result =
+            decoder.conceal_loss(reinterpret_cast<uint8_t*>(out.data()),
+                                 out.size() * sizeof(int16_t), kFrameSamples, bytes_written);
         check(result == micro_opus::OPUS_PACKET_DECODER_SUCCESS, "conceal_loss succeeds");
         check(bytes_written == kFrameBytes, "conceal_loss fills one frame");
     }
@@ -136,13 +143,15 @@ int main() {
     // --- Invalid arguments ---
     {
         size_t bytes_written = 7;
-        auto null_input = decoder.decode(nullptr, 10, out.data(), out.size(), bytes_written);
+        auto null_input = decoder.decode(nullptr, 10, reinterpret_cast<uint8_t*>(out.data()),
+                                         out.size() * sizeof(int16_t), bytes_written);
         check(null_input == micro_opus::OPUS_PACKET_DECODER_ERROR_INPUT_INVALID,
               "null input => INPUT_INVALID");
         check(bytes_written == 0, "invalid call clears bytes_written");
 
         auto empty_input =
-            decoder.decode(packets[0].data(), 0, out.data(), out.size(), bytes_written);
+            decoder.decode(packets[0].data(), 0, reinterpret_cast<uint8_t*>(out.data()),
+                           out.size() * sizeof(int16_t), bytes_written);
         check(empty_input == micro_opus::OPUS_PACKET_DECODER_ERROR_INPUT_INVALID,
               "empty input => INPUT_INVALID");
     }
@@ -153,8 +162,9 @@ int main() {
         check(decoder.get_required_output_bytes() == 0, "reset clears required_output_bytes");
         check(decoder.get_pcm_format().sample_rate() == kSampleRate, "reset preserves config");
         size_t bytes_written = 0;
-        auto result = decoder.decode(packets[0].data(), packets[0].size(), out.data(), out.size(),
-                                     bytes_written);
+        auto result = decoder.decode(packets[0].data(), packets[0].size(),
+                                     reinterpret_cast<uint8_t*>(out.data()),
+                                     out.size() * sizeof(int16_t), bytes_written);
         check(result == micro_opus::OPUS_PACKET_DECODER_SUCCESS, "decode works after reset");
         check(bytes_written == kFrameBytes, "post-reset frame size");
     }

--- a/include/micro_opus/ogg_opus_decoder.h
+++ b/include/micro_opus/ogg_opus_decoder.h
@@ -26,7 +26,6 @@
 #include <memory>
 
 // Forward declarations to avoid exposing implementation details
-struct OpusDecoder;
 struct OpusMSDecoder;
 
 // Forward declaration from micro_ogg namespace
@@ -43,6 +42,7 @@ constexpr uint32_t OPUS_DEFAULT_SAMPLE_RATE = 48000;  // Opus always decodes at 
 
 // Forward declarations
 struct OpusHead;
+class OpusPacketDecoder;
 
 /**
  * @brief Result codes for OggOpusDecoder operations
@@ -91,13 +91,16 @@ enum OggOpusResult : int8_t {
  *          threads without external synchronization.
  *
  * @note Lazy Allocation: The constructor always succeeds and does not allocate
- *       any resources. All allocations (OggDemuxer buffers, OpusHead, and Opus
- *       decoder instance) are deferred until the first call to decode().
+ *       any resources. Allocation is deferred to decode() and staged as the
+ *       stream is parsed: the OggDemuxer buffers on the first call, OpusHead when
+ *       the header is parsed, and the Opus decoder state once audio decoding
+ *       begins. For mono/stereo the libopus decoder state is created on the first
+ *       audio packet; for multistream it is created when OpusHead is parsed.
  *
- *       **First decode() call**: May return OGG_OPUS_ALLOCATION_FAILED if memory
- *       allocation fails (PSRAM or internal RAM). If this occurs, the decoder
- *       remains in an uninitialized state, and subsequent calls will retry
- *       allocation.
+ *       **While allocating**: Any of these early decode() calls may return
+ *       OGG_OPUS_ALLOCATION_FAILED if memory allocation fails (PSRAM or internal
+ *       RAM). The decoder leaves that resource uninitialized, and subsequent
+ *       calls retry the allocation.
  *
  *       **Subsequent calls**: Once allocation succeeds, decode() will never
  *       return OGG_OPUS_ALLOCATION_FAILED again unless reset() is called.
@@ -147,7 +150,8 @@ public:
      * @brief Construct a new Ogg Opus Decoder
      *
      * The constructor always succeeds and does not allocate any resources.
-     * All allocations are deferred to the first call to decode().
+     * All allocations are deferred to decode() and staged as the stream is
+     * parsed (see the class-level Lazy Allocation note).
      *
      * @param enable_crc Enable CRC32 validation of Ogg pages (default false)
      * @param sample_rate Output sample rate in Hz. Must be one of: 8000, 12000,
@@ -156,8 +160,8 @@ public:
      * @param channels Output channel count. 0 = use file's channel count (default).
      *                 1 = mono, 2 = stereo. The Opus decoder handles mixing/duplication.
      *
-     * @note This constructor is guaranteed not to fail. Resource allocation
-     *       is deferred to the first decode() call, which can return
+     * @note This constructor is guaranteed not to fail. Resource allocation is
+     *       deferred to decode(), where any of the early calls can return
      *       OGG_OPUS_ALLOCATION_FAILED if memory allocation fails.
      *
      * @note CRC Validation: When enabled, all Ogg pages are validated
@@ -193,15 +197,18 @@ public:
      * @return OggOpusResult result code
      *         - 0 (OGG_OPUS_OK): Success (check samples_decoded to see if you got samples)
      *         - Negative values: Error occurred
-     *           - OGG_OPUS_ALLOCATION_FAILED: Memory allocation failed (first call only)
+     *           - OGG_OPUS_ALLOCATION_FAILED: Memory allocation failed (during stream
+     *             initialization or, for mono/stereo, on the first audio packet)
      *           - OGG_OPUS_OUTPUT_BUFFER_TOO_SMALL: Output buffer too small
      *           - OGG_OPUS_INPUT_INVALID: Invalid stream
      *           - OGG_OPUS_DECODE_*: Opus decode errors (see OggOpusResult enum)
      *
-     * @note **Lazy Allocation**: On the first call, this method allocates internal
-     *       resources (~128KB, preferring PSRAM on ESP32). If allocation fails,
-     *       returns OGG_OPUS_ALLOCATION_FAILED and decoder remains uninitialized.
-     *       Subsequent calls will retry allocation until it succeeds.
+     * @note **Lazy Allocation**: The early decode() calls allocate internal
+     *       resources (~128KB total, preferring PSRAM on ESP32) as the stream is
+     *       parsed: the demuxer first, then the Opus decoder state once audio
+     *       decoding begins (deferred to the first audio packet for mono/stereo).
+     *       If an allocation fails, returns OGG_OPUS_ALLOCATION_FAILED and leaves
+     *       that resource uninitialized; subsequent calls retry until it succeeds.
      *
      * @note **Parameter Validation**: Both input and output pointers must be valid
      *       (non-null). Passing nullptr for either parameter will return
@@ -300,14 +307,14 @@ public:
     /**
      * @brief Reset the decoder state
      *
-     * Resets all internal state, allowing the decoder to be reused
-     * for a new stream. This does NOT deallocate internal buffers -
-     * they are preserved for reuse. After calling reset(), the next
-     * decode() call will NOT return OGG_OPUS_ALLOCATION_FAILED unless
-     * the decoder was never successfully initialized.
+     * Resets all internal state, allowing the decoder to be reused for a new
+     * stream. The OggDemuxer and its buffers are preserved for reuse, but the
+     * Opus decoder state is dropped and rebuilt from the next stream's OpusHead.
+     * Because of that rebuild, a subsequent decode() can still return
+     * OGG_OPUS_ALLOCATION_FAILED (for mono/stereo, on the first audio packet).
      *
-     * @note Preserves allocated buffers for efficiency. To fully release
-     *       memory, destroy the decoder instance.
+     * @note Preserves the demuxer's allocated buffers for efficiency. To fully
+     *       release memory, destroy the decoder instance.
      */
     void reset();
 
@@ -394,11 +401,10 @@ private:
     // Opus header info
     std::unique_ptr<OpusHead> opus_head_;
 
-    // Opus decoder instances (C API handles - managed with create/destroy)
-    // Only one of these will be non-null at a time:
-    // - opus_decoder_ for channel_mapping == 0 (mono/stereo)
-    // - opus_ms_decoder_ for channel_mapping != 0 (multistream with channel mapping)
-    OpusDecoder* opus_decoder_{nullptr};
+    // Opus decode backends. Only one is active at a time, selected by channel mapping family:
+    // - packet_decoder_ for channel_mapping == 0 (mono/stereo), via the raw-packet decoder
+    // - opus_ms_decoder_ for channel_mapping != 0 (multistream with a channel mapping table)
+    std::unique_ptr<OpusPacketDecoder> packet_decoder_;
     OpusMSDecoder* opus_ms_decoder_{nullptr};
 
     // --- 64-bit members ---

--- a/include/micro_opus/opus_packet_decoder.h
+++ b/include/micro_opus/opus_packet_decoder.h
@@ -1,0 +1,311 @@
+// Copyright 2026 Kevin Ahrendt
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// @file opus_packet_decoder.h
+/// @brief Raw Opus packet decoder (no Ogg container, no OpusHead)
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+// Forward declaration of the libopus C decoder handle to avoid exposing opus.h.
+struct OpusDecoder;
+
+namespace micro_opus {
+
+// ============================================================================
+// Public Types
+// ============================================================================
+
+/// @brief Result codes for OpusPacketDecoder operations
+///
+/// Non-negative values (>= 0) indicate success, negative values indicate errors. One error,
+/// OPUS_PACKET_DECODER_ERROR_OUTPUT_BUFFER_TOO_SMALL, is recoverable: size the output buffer with
+/// get_required_output_bytes() and retry the same call. Any other error leaves the decoder usable
+/// for the next packet but discards the current one.
+///
+/// This is a pre-framed decoder: the output format is supplied at construction (so there is no
+/// "format ready" event), each call consumes exactly one complete packet (so input is never
+/// "incomplete"), and there is no container to signal end-of-stream. It therefore returns only
+/// OPUS_PACKET_DECODER_SUCCESS or an error; the canonical streaming/informational codes do not
+/// apply.
+///
+/// Error checking pattern:
+/// - Use `result < 0` to check for errors
+/// - Use `result == OPUS_PACKET_DECODER_SUCCESS` to check for success (then read bytes_written)
+enum OpusPacketResult : int8_t {
+    // Success / informational (>= 0)
+    OPUS_PACKET_DECODER_SUCCESS = 0,  // Packet decoded (check bytes_written output parameter)
+
+    // Errors (< 0)
+    OPUS_PACKET_DECODER_ERROR_OUTPUT_BUFFER_TOO_SMALL =
+        -1,  // Output buffer can't hold this packet; size it with get_required_output_bytes()
+    OPUS_PACKET_DECODER_ERROR_INPUT_INVALID = -2,  // Null/empty packet or invalid arguments
+    OPUS_PACKET_DECODER_ERROR_ALLOCATION_FAILED =
+        -3,                                       // Decoder state allocation failed (first use)
+    OPUS_PACKET_DECODER_ERROR_DECODE_FAILED = -4  // libopus rejected the packet (corrupt/invalid)
+};
+
+/// @brief Format of the PCM that decode() produces
+///
+/// Describes the decoder's output, not a source file: a raw Opus stream carries no OpusHead, so the
+/// sample rate and channel count come from the constructor. The format is therefore valid
+/// immediately after construction (is_valid() is true), before the first decode() call. Bit depth
+/// is fixed because the decoder always emits 16-bit signed PCM.
+class PcmFormat {
+    friend class OpusPacketDecoder;
+
+    // 32-bit fields
+    uint32_t sample_rate_{0};  // Output sample rate in Hz (from the constructor)
+
+    // 8-bit fields
+    uint8_t num_channels_{0};  // Output channel count (from the constructor)
+
+public:
+    /// @brief Bits per output sample (always 16; microOpus emits 16-bit signed PCM)
+    /// @return Output bit depth in bits (always 16)
+    uint32_t bits_per_sample() const {
+        return 16;
+    }
+    /// @brief Bytes per output sample (always 2; microOpus emits 16-bit signed PCM)
+    /// @return Output bytes per sample (always 2)
+    uint32_t bytes_per_sample() const {
+        return 2;
+    }
+    /// @brief Safe output buffer size, in bytes, for any single decode() call
+    ///
+    /// Sized for the Opus worst case: a 120 ms packet, which at the output rate is
+    /// sample_rate / 1000 * 120 samples per channel. Allocate this many bytes and decode() never
+    /// returns OPUS_PACKET_DECODER_ERROR_OUTPUT_BUFFER_TOO_SMALL; pass it directly as decode()'s
+    /// output_size_bytes.
+    /// @return Output buffer size in bytes (all channels), or 0 before the format is set
+    uint32_t max_output_bytes() const {
+        return (this->sample_rate_ / 1000u * 120u) * this->num_channels_ * this->bytes_per_sample();
+    }
+    /// @brief Number of output channels (1 = mono, 2 = stereo)
+    /// @return Output channel count, or 0 before the format is set
+    uint32_t num_channels() const {
+        return this->num_channels_;
+    }
+    /// @brief Output sample rate in Hz (8000, 12000, 16000, 24000, or 48000)
+    /// @return Sample rate in Hz, or 0 before the format is set
+    uint32_t sample_rate() const {
+        return this->sample_rate_;
+    }
+    /// @brief Whether the PCM format has been populated (true immediately after construction)
+    /// @return true once the PCM format is available
+    bool is_valid() const {
+        return this->sample_rate_ != 0;
+    }
+};
+
+// ============================================================================
+// OpusPacketDecoder
+// ============================================================================
+
+/**
+ * @brief Raw Opus packet decoder (no Ogg, no OpusHead)
+ *
+ * Decodes individual, complete Opus packets without any container framing. Each call to decode()
+ * must be handed exactly one whole packet (as delivered by a transport that already frames them,
+ * e.g. an RTP payload or a length-prefixed application stream). The stream carries no OpusHead, so
+ * the caller supplies the output sample rate and channel count at construction.
+ *
+ * Use this when an upstream layer guarantees packet boundaries. For Ogg-contained Opus files use
+ * OggOpusDecoder instead, which parses the container and OpusHead for you.
+ *
+ * @warning Thread Safety: This class is NOT thread-safe. Each decoder instance must be accessed
+ * from only one thread at a time. To decode multiple streams concurrently, create one decoder per
+ * thread.
+ *
+ * @note Lazy Allocation: The constructor always succeeds and does not allocate. The libopus decoder
+ *       state is allocated on the first decode() (or conceal_loss()) call, preferring PSRAM on
+ * ESP32 per the OPUS_STATE_MEMORY_PREFERENCE Kconfig. If allocation fails, that call returns
+ *       OPUS_PACKET_DECODER_ERROR_ALLOCATION_FAILED and the decoder stays uninitialized; later
+ * calls retry. Once allocation succeeds it does not recur.
+ *
+ * @note Channels: mono and stereo only (Opus channel mapping family 0). A raw stream provides no
+ *       channel mapping table, which multistream (> 2 channels) decoding would require.
+ *
+ * Usage:
+ * 1. Construct with the stream's sample rate and channel count (constructor always succeeds)
+ * 2. Size an output buffer from get_pcm_format().max_output_bytes() (or grow lazily; see below)
+ * 3. Call decode() with one complete Opus packet per call
+ * 4. Check the return value: result < 0 means error; OPUS_PACKET_DECODER_SUCCESS yields
+ * bytes_written
+ *
+ * Example:
+ * @code
+ * micro_opus::OpusPacketDecoder decoder(48000, 2);  // 48 kHz stereo
+ *
+ * const auto& fmt = decoder.get_pcm_format();
+ * std::vector<uint8_t> pcm(fmt.max_output_bytes());
+ *
+ * for (const Packet& p : packets) {
+ *     size_t bytes_written = 0;
+ *     auto result = decoder.decode(p.data, p.size, pcm.data(), pcm.size(), bytes_written);
+ *     if (result < 0) {
+ *         break;  // With the buffer sized above, OUTPUT_BUFFER_TOO_SMALL never fires
+ *     }
+ *     // bytes_written is the total across all channels; e.g. a 20 ms stereo packet at 48 kHz
+ *     // is 960 frames => 1920 samples => 3840 bytes.
+ *     process_audio(reinterpret_cast<int16_t*>(pcm.data()), bytes_written / sizeof(int16_t));
+ * }
+ * @endcode
+ */
+class OpusPacketDecoder {
+public:
+    // ========================================
+    // Lifecycle
+    // ========================================
+
+    /// @brief Construct a raw Opus packet decoder
+    ///
+    /// The constructor always succeeds and does not allocate; the libopus decoder state is created
+    /// lazily on the first decode() call. The PCM format is populated immediately, so
+    /// get_pcm_format() is usable before decoding.
+    ///
+    /// @param sample_rate Output sample rate in Hz. Must be one of 8000, 12000, 16000, 24000, or
+    ///                    48000 (the rates Opus can decode to); other values are rejected on the
+    ///                    first decode() call. Default 48000 (native Opus rate).
+    /// @param channels Output channel count: 1 (mono) or 2 (stereo). Default 2.
+    explicit OpusPacketDecoder(uint32_t sample_rate = 48000, uint8_t channels = 2);
+
+    /// @brief Destroy the decoder and free the libopus decoder state
+    ~OpusPacketDecoder();
+
+    // Non-copyable, non-movable: owns a libopus decoder handle (a fixed-in-place resource).
+    OpusPacketDecoder(const OpusPacketDecoder&) = delete;
+    OpusPacketDecoder& operator=(const OpusPacketDecoder&) = delete;
+    OpusPacketDecoder(OpusPacketDecoder&&) = delete;
+    OpusPacketDecoder& operator=(OpusPacketDecoder&&) = delete;
+
+    /// @brief Reset the decoder's inter-packet state, ready for a new stream
+    ///
+    /// Clears the libopus decoder's internal history (the state carried between consecutive
+    /// packets) and the required-output-bytes counter. The configured sample rate and channel
+    /// count, and the allocated decoder buffer, are preserved, so the next decode() does not
+    /// re-allocate or return OPUS_PACKET_DECODER_ERROR_ALLOCATION_FAILED (unless the decoder was
+    /// never initialized). To fully release memory, destroy the instance.
+    void reset();
+
+    // ========================================
+    // Core Decoding API
+    // ========================================
+
+    /// @brief Decode one complete Opus packet to PCM
+    ///
+    /// Each call must provide exactly one whole Opus packet. The decoder writes 16-bit signed PCM,
+    /// interleaved in channel order.
+    ///
+    /// @param input Pointer to the Opus packet (must not be nullptr)
+    /// @param input_len Number of bytes in the packet (must not be 0)
+    /// @param output Pointer to the output buffer (must not be nullptr). Must be aligned for
+    /// int16_t
+    ///               access (2-byte alignment); buffers from new/malloc/heap_caps_malloc satisfy
+    ///               this.
+    /// @param output_size_bytes Number of bytes available in the output buffer
+    /// @param[out] bytes_written Number of PCM bytes written (total across all channels; e.g. a
+    ///                           stereo packet of 960 frames => 1920 samples => 3840 bytes). Set to
+    ///                           0 on any error.
+    ///
+    /// @return OPUS_PACKET_DECODER_SUCCESS, or a negative error code; see OpusPacketResult
+    ///
+    /// @note On OPUS_PACKET_DECODER_ERROR_OUTPUT_BUFFER_TOO_SMALL, call get_required_output_bytes()
+    ///       for the exact size this packet needs, grow the buffer, and retry the same call.
+    /// @note output_size_bytes and bytes_written are both in bytes, matching the output buffer's
+    /// unit.
+    OpusPacketResult decode(const uint8_t* input, size_t input_len, uint8_t* output,
+                            size_t output_size_bytes, size_t& bytes_written);
+
+    /// @brief Synthesize concealment audio for a lost packet (packet-loss concealment)
+    ///
+    /// When a packet is known to be lost, call this in its place to let libopus extrapolate one
+    /// frame of audio from the decoder's recent history. The decoder state advances as if the lost
+    /// packet had been decoded, keeping later packets aligned.
+    ///
+    /// @param output Pointer to the output buffer (must not be nullptr), aligned for int16_t access
+    /// @param output_size_bytes Number of bytes available in the output buffer
+    /// @param frame_size_samples Number of samples per channel to synthesize. Must be a valid Opus
+    ///                           frame size at the configured rate (a multiple of 2.5 ms, e.g. 960
+    ///                           for 20 ms at 48 kHz); typically the frame size of the surrounding
+    ///                           packets. Must not be 0.
+    /// @param[out] bytes_written Number of PCM bytes written (total across all channels). Set to 0
+    /// on
+    ///                           any error.
+    ///
+    /// @return OPUS_PACKET_DECODER_SUCCESS, or a negative error code; see OpusPacketResult
+    OpusPacketResult conceal_loss(uint8_t* output, size_t output_size_bytes,
+                                  size_t frame_size_samples, size_t& bytes_written);
+
+    // ========================================
+    // PCM Format
+    // ========================================
+
+    /// @brief Get the format of the PCM that decode() produces
+    ///
+    /// Valid immediately after construction (the format comes from the constructor, not a header).
+    ///
+    /// @return Reference to the PcmFormat struct
+    const PcmFormat& get_pcm_format() const {
+        return this->pcm_format_;
+    }
+
+    // ========================================
+    // Output Buffer Helpers
+    // ========================================
+
+    /// @brief Get the required output buffer size, in bytes, for the last packet
+    ///
+    /// Returns the byte count (across all channels) the most recently processed packet needs. Call
+    /// it after OPUS_PACKET_DECODER_ERROR_OUTPUT_BUFFER_TOO_SMALL to size the buffer before
+    /// retrying. Unlike PcmFormat::max_output_bytes() (a stream-wide upper bound), this is the
+    /// exact size the last packet needs, so callers that allocate lazily can grow to fit each
+    /// packet.
+    ///
+    /// @return Required size in bytes (all channels), or 0 if no packet has been processed yet
+    size_t get_required_output_bytes() const {
+        return this->required_output_bytes_;
+    }
+
+private:
+    // ========================================
+    // Decode Pipeline
+    // ========================================
+
+    /// @brief Create the libopus decoder state on first use (lazy allocation)
+    OpusPacketResult ensure_decoder();
+
+    // ========================================
+    // Member Variables
+    // ========================================
+
+    // Struct fields
+
+    // Output PCM format (populated by the constructor)
+    PcmFormat pcm_format_{};
+
+    // Pointer fields
+
+    // libopus decoder handle (created lazily on first decode; nullptr until then)
+    OpusDecoder* opus_decoder_{nullptr};
+
+    // size_t fields
+
+    // Output byte count (all channels) the last packet needs
+    size_t required_output_bytes_{0};
+};
+
+}  // namespace micro_opus

--- a/include/micro_opus/opus_packet_decoder.h
+++ b/include/micro_opus/opus_packet_decoder.h
@@ -202,6 +202,23 @@ public:
     void reset();
 
     // ========================================
+    // Configuration
+    // ========================================
+
+    /// @brief Apply a fixed output gain to all decoded audio (Ogg Opus OpusHead "output gain")
+    ///
+    /// Sets a gain that libopus applies to every decoded frame, matching the OpusHead output_gain
+    /// field (Q7.8 dB: the stored value divided by 256 gives dB). A raw Opus stream carries no such
+    /// field, so it defaults to 0 (unity gain); it exists so a container parser like OggOpusDecoder
+    /// can forward the header value.
+    ///
+    /// Takes effect on the next decoder allocation, or immediately if the decoder already exists.
+    /// The gain is preserved across reset() (libopus keeps it through OPUS_RESET_STATE).
+    ///
+    /// @param output_gain Output gain in Q7.8 dB units (0 = unity gain)
+    void set_output_gain(int16_t output_gain);
+
+    // ========================================
     // Core Decoding API
     // ========================================
 
@@ -306,6 +323,11 @@ private:
 
     // Output byte count (all channels) the last packet needs
     size_t required_output_bytes_{0};
+
+    // 16-bit fields
+
+    // Fixed output gain (Q7.8 dB) applied via OPUS_SET_GAIN; 0 = unity. From set_output_gain().
+    int16_t output_gain_{0};
 };
 
 }  // namespace micro_opus

--- a/include/micro_opus/opus_packet_decoder.h
+++ b/include/micro_opus/opus_packet_decoder.h
@@ -90,24 +90,27 @@ public:
     /// sample_rate / 1000 * 120 samples per channel. Allocate this many bytes and decode() never
     /// returns OPUS_PACKET_DECODER_ERROR_OUTPUT_BUFFER_TOO_SMALL; pass it directly as decode()'s
     /// output_size_bytes.
-    /// @return Output buffer size in bytes (all channels), or 0 before the format is set
+    /// @return Output buffer size in bytes (all channels)
     uint32_t max_output_bytes() const {
         return (this->sample_rate_ / 1000u * 120u) * this->num_channels_ * this->bytes_per_sample();
     }
     /// @brief Number of output channels (1 = mono, 2 = stereo)
-    /// @return Output channel count, or 0 before the format is set
+    /// @return Output channel count
     uint32_t num_channels() const {
         return this->num_channels_;
     }
     /// @brief Output sample rate in Hz (8000, 12000, 16000, 24000, or 48000)
-    /// @return Sample rate in Hz, or 0 before the format is set
+    /// @return Sample rate in Hz
     uint32_t sample_rate() const {
         return this->sample_rate_;
     }
-    /// @brief Whether the PCM format has been populated (true immediately after construction)
-    /// @return true once the PCM format is available
+    /// @brief Whether the stream's PCM format is known
+    ///
+    /// Always true for this decoder: the format is supplied at construction, so it is known as soon
+    /// as the object exists.
+    /// @return true (the format is always available once constructed)
     bool is_valid() const {
-        return this->sample_rate_ != 0;
+        return true;
     }
 };
 
@@ -151,17 +154,20 @@ public:
  * micro_opus::OpusPacketDecoder decoder(48000, 2);  // 48 kHz stereo
  *
  * const auto& fmt = decoder.get_pcm_format();
- * std::vector<uint8_t> pcm(fmt.max_output_bytes());
+ * // int16_t buffer: naturally aligned for the decoder's 16-bit PCM output. The API stays byte-
+ * // oriented, so cast to uint8_t* and pass the size in bytes at the call site.
+ * std::vector<int16_t> pcm(fmt.max_output_bytes() / sizeof(int16_t));
  *
  * for (const Packet& p : packets) {
  *     size_t bytes_written = 0;
- *     auto result = decoder.decode(p.data, p.size, pcm.data(), pcm.size(), bytes_written);
+ *     auto result = decoder.decode(p.data, p.size, reinterpret_cast<uint8_t*>(pcm.data()),
+ *                                  pcm.size() * sizeof(int16_t), bytes_written);
  *     if (result < 0) {
  *         break;  // With the buffer sized above, OUTPUT_BUFFER_TOO_SMALL never fires
  *     }
  *     // bytes_written is the total across all channels; e.g. a 20 ms stereo packet at 48 kHz
  *     // is 960 frames => 1920 samples => 3840 bytes.
- *     process_audio(reinterpret_cast<int16_t*>(pcm.data()), bytes_written / sizeof(int16_t));
+ *     process_audio(pcm.data(), bytes_written / sizeof(int16_t));
  * }
  * @endcode
  */

--- a/src/ogg_opus_decoder.cpp
+++ b/src/ogg_opus_decoder.cpp
@@ -18,6 +18,7 @@
 
 #include "micro_opus/ogg_opus_decoder.h"
 
+#include "micro_opus/opus_packet_decoder.h"
 #include "opus.h"
 #include "opus_header.h"
 #include "opus_multistream.h"
@@ -67,6 +68,24 @@ const size_t MAX_OPUS_TAGS_SIZE = 125829120;
 // RFC 7845 Section 5.2: Minimum OpusTags size
 // Must contain: magic(8) + vendor_length(4) + user_comment_count(4) = 16 bytes
 const size_t MIN_OPUS_TAGS_SIZE = 16;
+
+// Translate a raw-packet-decoder result into the Ogg wrapper's result code.
+OggOpusResult map_packet_decoder_result(OpusPacketResult result) {
+    switch (result) {
+        case OPUS_PACKET_DECODER_SUCCESS:
+            return OGG_OPUS_OK;
+        case OPUS_PACKET_DECODER_ERROR_OUTPUT_BUFFER_TOO_SMALL:
+            return OGG_OPUS_OUTPUT_BUFFER_TOO_SMALL;
+        case OPUS_PACKET_DECODER_ERROR_ALLOCATION_FAILED:
+            return OGG_OPUS_ALLOCATION_FAILED;
+        case OPUS_PACKET_DECODER_ERROR_INPUT_INVALID:
+            return OGG_OPUS_INPUT_INVALID;
+        // DECODE_FAILED and any unhandled or future result map to a decode error.
+        case OPUS_PACKET_DECODER_ERROR_DECODE_FAILED:
+        default:
+            return OGG_OPUS_DECODE_ERROR;
+    }
+}
 }  // namespace
 
 OggOpusResult OggOpusDecoder::process_packet(const micro_ogg::OggPacket& packet, uint8_t* output,
@@ -140,15 +159,11 @@ OggOpusResult OggOpusDecoder::validate_granule_position(int64_t granule_pos, siz
 OggOpusResult OggOpusDecoder::create_opus_decoder(uint8_t output_channels) {
     int error = 0;
     if (opus_head_->channel_mapping == 0) {
-        opus_decoder_ = opus_decoder_create(sample_rate_, output_channels, &error);
-
-        if (error != OPUS_OK || !opus_decoder_) {
-            return OGG_OPUS_ALLOCATION_FAILED;
-        }
-
-        if (opus_head_->output_gain != 0) {
-            opus_decoder_ctl(opus_decoder_, OPUS_SET_GAIN((opus_int32)opus_head_->output_gain));
-        }
+        // Mono/stereo: delegate decoding to the raw-packet decoder. Construction never allocates or
+        // fails; the libopus state is created lazily on the first decode(), so an allocation
+        // failure surfaces on the first audio packet rather than here.
+        packet_decoder_ = std::make_unique<OpusPacketDecoder>(sample_rate_, output_channels);
+        packet_decoder_->set_output_gain(opus_head_->output_gain);
     } else {
         opus_ms_decoder_ = opus_multistream_decoder_create(
             sample_rate_, output_channels, opus_head_->stream_count, opus_head_->coupled_count,
@@ -361,31 +376,32 @@ OggOpusResult OggOpusDecoder::handle_audio_packet(const uint8_t* packet_data, si
         }
     }
 
-    size_t max_samples = output_size / (output_channels_ * sizeof(int16_t));
-    int max_frame_size = (int)std::min(max_samples, (size_t)INT_MAX);
-
-    // Decode Opus packet
-    // Cast uint8_t* output buffer to int16_t* for the Opus decoder
-    int16_t* pcm_output = reinterpret_cast<int16_t*>(output);
-    int decoded_samples_int = 0;
-    if (opus_decoder_) {
-        decoded_samples_int = opus_decode(opus_decoder_, packet_data, (opus_int32)packet_len,
-                                          pcm_output, max_frame_size,
-                                          0  // No FEC
-        );
+    // Decode the packet into the caller's buffer. Mono/stereo go through the raw-packet decoder;
+    // multistream (channel mapping family 1) uses libopus's multistream API directly. The
+    // buffer-size check above means the raw-packet decoder never reports OUTPUT_BUFFER_TOO_SMALL.
+    size_t decoded_samples_size = 0;
+    if (packet_decoder_) {
+        size_t bytes_written = 0;
+        OpusPacketResult packet_result =
+            packet_decoder_->decode(packet_data, packet_len, output, output_size, bytes_written);
+        if (packet_result != OPUS_PACKET_DECODER_SUCCESS) {
+            return map_packet_decoder_result(packet_result);
+        }
+        decoded_samples_size = bytes_written / (output_channels_ * sizeof(int16_t));
     } else if (opus_ms_decoder_) {
-        decoded_samples_int = opus_multistream_decode(
-            opus_ms_decoder_, packet_data, (opus_int32)packet_len, pcm_output, max_frame_size,
-            0  // No FEC
-        );
+        size_t max_samples = output_size / (output_channels_ * sizeof(int16_t));
+        int max_frame_size = (int)std::min(max_samples, (size_t)INT_MAX);
+        int decoded_samples_int = opus_multistream_decode(
+            opus_ms_decoder_, packet_data, (opus_int32)packet_len,
+            reinterpret_cast<int16_t*>(output), max_frame_size, 0 /* No FEC */);
+        if (decoded_samples_int < 0) {
+            return OGG_OPUS_DECODE_ERROR;
+        }
+        decoded_samples_size = (size_t)decoded_samples_int;
     } else {
+        // Unreachable in STATE_DECODING: create_opus_decoder() always sets one backend.
         return OGG_OPUS_NOT_INITIALIZED;
     }
-
-    if (decoded_samples_int < 0) {
-        return OGG_OPUS_DECODE_ERROR;
-    }
-    size_t decoded_samples_size = (size_t)decoded_samples_int;
 
     update_page_tracking(is_last_on_page);
 
@@ -497,24 +513,18 @@ OggOpusDecoder::OggOpusDecoder(bool enable_crc, uint32_t sample_rate, uint8_t ch
 }
 
 OggOpusDecoder::~OggOpusDecoder() {
-    if (opus_decoder_) {
-        opus_decoder_destroy(opus_decoder_);
-        opus_decoder_ = nullptr;
-    }
-
     if (opus_ms_decoder_) {
         opus_multistream_decoder_destroy(opus_ms_decoder_);
         opus_ms_decoder_ = nullptr;
     }
 
-    // ogg_demuxer_ and opus_head_ are automatically cleaned up by unique_ptr
+    // packet_decoder_, ogg_demuxer_, and opus_head_ are automatically cleaned up by unique_ptr
 }
 
 void OggOpusDecoder::reset() {
-    if (opus_decoder_) {
-        opus_decoder_destroy(opus_decoder_);
-        opus_decoder_ = nullptr;
-    }
+    // Drop the mono/stereo backend; a new one is built on the next OpusHead with that stream's
+    // channel count and gain.
+    packet_decoder_.reset();
 
     if (opus_ms_decoder_) {
         opus_multistream_decoder_destroy(opus_ms_decoder_);

--- a/src/opus_packet_decoder.cpp
+++ b/src/opus_packet_decoder.cpp
@@ -1,0 +1,152 @@
+// Copyright 2026 Kevin Ahrendt
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* Raw Opus Packet Decoder
+ * Implementation of OpusPacketDecoder class
+ */
+
+#include "micro_opus/opus_packet_decoder.h"
+
+#include "opus.h"
+
+#include <algorithm>
+#include <climits>
+
+namespace micro_opus {
+
+// ============================================================================
+// Lifecycle
+// ============================================================================
+
+OpusPacketDecoder::OpusPacketDecoder(uint32_t sample_rate, uint8_t channels) {
+    this->pcm_format_.sample_rate_ = sample_rate;
+    this->pcm_format_.num_channels_ = channels;
+}
+
+OpusPacketDecoder::~OpusPacketDecoder() {
+    if (this->opus_decoder_ != nullptr) {
+        opus_decoder_destroy(this->opus_decoder_);
+        this->opus_decoder_ = nullptr;
+    }
+}
+
+void OpusPacketDecoder::reset() {
+    if (this->opus_decoder_ != nullptr) {
+        opus_decoder_ctl(this->opus_decoder_, OPUS_RESET_STATE);
+    }
+    this->required_output_bytes_ = 0;
+}
+
+// ============================================================================
+// Core Decoding API
+// ============================================================================
+
+OpusPacketResult OpusPacketDecoder::decode(const uint8_t* input, size_t input_len, uint8_t* output,
+                                           size_t output_size_bytes, size_t& bytes_written) {
+    bytes_written = 0;
+
+    if (input == nullptr || input_len == 0 || output == nullptr) {
+        return OPUS_PACKET_DECODER_ERROR_INPUT_INVALID;
+    }
+
+    OpusPacketResult init_result = this->ensure_decoder();
+    if (init_result < 0) {
+        return init_result;
+    }
+
+    const size_t bytes_per_frame = this->pcm_format_.num_channels() * sizeof(int16_t);
+
+    // An invalid packet makes opus_packet_get_nb_samples() return < 0; skip the up-front size
+    // check then and let opus_decode() report the specific failure.
+    int nb_samples =
+        opus_packet_get_nb_samples(input, static_cast<opus_int32>(input_len),
+                                   static_cast<opus_int32>(this->pcm_format_.sample_rate()));
+    if (nb_samples > 0) {
+        this->required_output_bytes_ = static_cast<size_t>(nb_samples) * bytes_per_frame;
+        if (output_size_bytes < this->required_output_bytes_) {
+            return OPUS_PACKET_DECODER_ERROR_OUTPUT_BUFFER_TOO_SMALL;
+        }
+    }
+
+    int max_frame_size = static_cast<int>(
+        std::min(output_size_bytes / bytes_per_frame, static_cast<size_t>(INT_MAX)));
+
+    int decoded = opus_decode(this->opus_decoder_, input, static_cast<opus_int32>(input_len),
+                              reinterpret_cast<int16_t*>(output), max_frame_size, 0);
+    if (decoded < 0) {
+        return (decoded == OPUS_BUFFER_TOO_SMALL)
+                   ? OPUS_PACKET_DECODER_ERROR_OUTPUT_BUFFER_TOO_SMALL
+                   : OPUS_PACKET_DECODER_ERROR_DECODE_FAILED;
+    }
+
+    bytes_written = static_cast<size_t>(decoded) * bytes_per_frame;
+    return OPUS_PACKET_DECODER_SUCCESS;
+}
+
+OpusPacketResult OpusPacketDecoder::conceal_loss(uint8_t* output, size_t output_size_bytes,
+                                                 size_t frame_size_samples, size_t& bytes_written) {
+    bytes_written = 0;
+
+    if (output == nullptr || frame_size_samples == 0) {
+        return OPUS_PACKET_DECODER_ERROR_INPUT_INVALID;
+    }
+
+    OpusPacketResult init_result = this->ensure_decoder();
+    if (init_result < 0) {
+        return init_result;
+    }
+
+    const size_t bytes_per_frame = this->pcm_format_.num_channels() * sizeof(int16_t);
+
+    this->required_output_bytes_ = frame_size_samples * bytes_per_frame;
+    if (output_size_bytes < this->required_output_bytes_) {
+        return OPUS_PACKET_DECODER_ERROR_OUTPUT_BUFFER_TOO_SMALL;
+    }
+
+    // A null packet asks libopus to synthesize one frame of concealment audio from recent history.
+    int decoded = opus_decode(this->opus_decoder_, nullptr, 0, reinterpret_cast<int16_t*>(output),
+                              static_cast<int>(frame_size_samples), 0);
+    if (decoded < 0) {
+        return (decoded == OPUS_BUFFER_TOO_SMALL)
+                   ? OPUS_PACKET_DECODER_ERROR_OUTPUT_BUFFER_TOO_SMALL
+                   : OPUS_PACKET_DECODER_ERROR_DECODE_FAILED;
+    }
+
+    bytes_written = static_cast<size_t>(decoded) * bytes_per_frame;
+    return OPUS_PACKET_DECODER_SUCCESS;
+}
+
+// ============================================================================
+// Decode Pipeline
+// ============================================================================
+
+OpusPacketResult OpusPacketDecoder::ensure_decoder() {
+    if (this->opus_decoder_ != nullptr) {
+        return OPUS_PACKET_DECODER_SUCCESS;
+    }
+
+    int error = 0;
+    this->opus_decoder_ =
+        opus_decoder_create(static_cast<opus_int32>(this->pcm_format_.sample_rate()),
+                            static_cast<int>(this->pcm_format_.num_channels()), &error);
+    if (this->opus_decoder_ == nullptr) {
+        // OPUS_BAD_ARG means an unsupported sample rate or channel count was given to the
+        // constructor; anything else (e.g. OPUS_ALLOC_FAIL) is an out-of-memory condition.
+        return (error == OPUS_BAD_ARG) ? OPUS_PACKET_DECODER_ERROR_INPUT_INVALID
+                                       : OPUS_PACKET_DECODER_ERROR_ALLOCATION_FAILED;
+    }
+    return OPUS_PACKET_DECODER_SUCCESS;
+}
+
+}  // namespace micro_opus

--- a/src/opus_packet_decoder.cpp
+++ b/src/opus_packet_decoder.cpp
@@ -49,6 +49,18 @@ void OpusPacketDecoder::reset() {
 }
 
 // ============================================================================
+// Configuration
+// ============================================================================
+
+void OpusPacketDecoder::set_output_gain(int16_t output_gain) {
+    this->output_gain_ = output_gain;
+    // Apply now if the decoder already exists; otherwise ensure_decoder() applies it on creation.
+    if (this->opus_decoder_ != nullptr) {
+        opus_decoder_ctl(this->opus_decoder_, OPUS_SET_GAIN(static_cast<opus_int32>(output_gain)));
+    }
+}
+
+// ============================================================================
 // Core Decoding API
 // ============================================================================
 
@@ -145,6 +157,13 @@ OpusPacketResult OpusPacketDecoder::ensure_decoder() {
         // constructor; anything else (e.g. OPUS_ALLOC_FAIL) is an out-of-memory condition.
         return (error == OPUS_BAD_ARG) ? OPUS_PACKET_DECODER_ERROR_INPUT_INVALID
                                        : OPUS_PACKET_DECODER_ERROR_ALLOCATION_FAILED;
+    }
+
+    // Apply any gain set before allocation (e.g. a forwarded OpusHead output_gain).
+    // Unity gain (0) is the libopus default, so skip the ctl.
+    if (this->output_gain_ != 0) {
+        opus_decoder_ctl(this->opus_decoder_,
+                         OPUS_SET_GAIN(static_cast<opus_int32>(this->output_gain_)));
     }
     return OPUS_PACKET_DECODER_SUCCESS;
 }


### PR DESCRIPTION
## Summary

Adds `OpusPacketDecoder`, a decoder for raw standalone Opus packets (no Ogg
container, no OpusHead), and refactors `OggOpusDecoder` so its mono/stereo path
decodes through it. This covers transports that already frame packets (RTP
payloads, length-prefixed application streams), where the existing Ogg-only
wrapper did not apply.

Two commits:
1. `OpusPacketDecoder` (standalone, additive).
2. `OggOpusDecoder` routes channel-mapping-family-0 decode through it.

## OpusPacketDecoder

- One complete packet per `decode()` call. Sample rate and channel count are
  supplied at construction; there is no container or header to parse.
- Byte-counted PcmFormat API consistent with the rest of the decoder family:
  `decode()` reports `bytes_written`, `get_pcm_format()` describes the output,
  and `get_required_output_bytes()` / `PcmFormat::max_output_bytes()` size the
  buffer.
- Result codes `OPUS_PACKET_DECODER_*`. `OUTPUT_BUFFER_TOO_SMALL` is the one
  recoverable error: size with `get_required_output_bytes()` and retry.
- `conceal_loss()` synthesizes one frame of packet-loss concealment.
- `set_output_gain()` applies an OpusHead-style Q7.8 gain (added in commit 2 so
  the Ogg wrapper can forward it).
- mono/stereo only (channel mapping family 0). Lazy allocation: the constructor
  never allocates or fails; the libopus state is created on the first
  `decode()`/`conceal_loss()`, preferring PSRAM on ESP32. Not thread-safe (one
  instance per thread), matching `OggOpusDecoder`.

## OggOpusDecoder delegation (hybrid)

- Mono/stereo (family 0) now decodes through an owned `OpusPacketDecoder`
  instead of calling `opus_decode()` directly. The OpusHead output gain is
  forwarded via `set_output_gain()`.
- Multistream/surround (family 1, up to 8 channels) is unchanged and still uses
  `opus_multistream_decode()`, keeping all current behavior and the
  `test_silent_channels` coverage.
- `OPUS_PACKET_DECODER_*` results are mapped back to `OGG_OPUS_*`. Everything
  Ogg-specific (demux, header parsing, granule validation, end-trimming,
  pre-skip) is untouched.
- Public API and decoded output are unchanged. One behavior nuance: for
  mono/stereo the libopus state now allocates on the first audio packet rather
  than at OpusHead, so `OGG_OPUS_ALLOCATION_FAILED` (and an unsupported sample
  rate or channel count) can surface there instead. The lazy-allocation and
  `reset()` docs are updated to match.

## Testing

- New host round-trip test `test_raw_packet` covers output sizing,
  buffer-too-small recovery, concealment, and `reset()`.
- `test_chunked` (stereo Ogg, tiny-chunk feeds), `test_silent_channels`
  (multistream), and `test_raw_packet` pass under ASan/UBSan.
- Decoded WAV output is byte-identical to the pre-refactor implementation on a
  real stereo stream, confirming the gain, pre-skip, and end-trim paths are
  unchanged.

## Follow-ups (not in this PR)

- README usage section for `OpusPacketDecoder` (currently only `OggOpusDecoder`
  is documented).