### PR TITLE
Lint tests with clang-tidy; rename test constants to UPPER_CASE

### DIFF
--- a/include/micro_opus/opus_packet_decoder.h
+++ b/include/micro_opus/opus_packet_decoder.h
@@ -92,7 +92,7 @@ public:
     /// output_size_bytes.
     /// @return Output buffer size in bytes (all channels)
     uint32_t max_output_bytes() const {
-        return (this->sample_rate_ / 1000u * 120u) * this->num_channels_ * this->bytes_per_sample();
+        return (this->sample_rate_ / 1000U * 120U) * this->num_channels_ * this->bytes_per_sample();
     }
     /// @brief Number of output channels (1 = mono, 2 = stereo)
     /// @return Output channel count

--- a/script/clang-tidy.sh
+++ b/script/clang-tidy.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-# Run clang-tidy on source files
-# Requires a compile_commands.json in the build directory
+# Run clang-tidy on production sources (src/, host_examples/) and host test sources
+# (tests/unit/, tests/conformance/).
+# Requires a compile_commands.json in each build directory (host_examples/opus_to_wav/build
+# and tests/build); the tests one is auto-generated via cmake if absent.
 
 set -e
 
@@ -40,10 +42,7 @@ if [ ! -f "${BUILD_DIR}/compile_commands.json" ]; then
 fi
 
 # Find all source files, excluding lib/ and build/ directories
-# Note: examples/ excluded as ESP-IDF code can't be checked without ESP-IDF headers.
-# Note: tests/ is intentionally excluded. Test code uses looser idioms (magic numbers in crafted
-# byte streams, etc.) and builds from a different compile database; it is covered by clang-format
-# (see .pre-commit-config.yaml) but not clang-tidy.
+# Note: examples/ and tests/qemu/ excluded as ESP-IDF code can't be checked without ESP-IDF headers.
 SOURCES=$(find "$ROOT_DIR/src" "$ROOT_DIR/host_examples" \
     -path '*/build' -prune -o \
     -path '*/lib' -prune -o \
@@ -54,11 +53,28 @@ if [ -z "$SOURCES" ]; then
     exit 0
 fi
 
+# Host test sources use their own compile database (tests/build). They inherit every rule from the
+# root .clang-tidy except readability-magic-numbers, which tests/.clang-tidy disables. qemu/ is an
+# ESP-IDF app and can't be checked on the host, so it is left out.
+TEST_BUILD_DIR="${ROOT_DIR}/tests/build"
+TEST_SOURCES=$(find "$ROOT_DIR/tests/unit" "$ROOT_DIR/tests/conformance" \
+    -name '*.cpp' -print 2>/dev/null || true)
+
+if [ -n "$TEST_SOURCES" ] && [ ! -f "${TEST_BUILD_DIR}/compile_commands.json" ]; then
+    echo "Generating tests/build/compile_commands.json..."
+    cmake -B "$TEST_BUILD_DIR" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON "${ROOT_DIR}/tests"
+fi
+
 # Parse arguments
 FIX_FLAG=""
 if [ "$1" = "--fix" ]; then
     FIX_FLAG="--fix"
 fi
 
-echo "Running clang-tidy..."
+echo "Running clang-tidy on src/ and host_examples/..."
 $CLANG_TIDY -p "$BUILD_DIR" $FIX_FLAG $SOURCES
+
+if [ -n "$TEST_SOURCES" ]; then
+    echo "Running clang-tidy on tests/..."
+    $CLANG_TIDY -p "$TEST_BUILD_DIR" $FIX_FLAG $TEST_SOURCES
+fi

--- a/tests/.clang-tidy
+++ b/tests/.clang-tidy
@@ -1,0 +1,14 @@
+# Test code inherits every rule from the root .clang-tidy, with two exceptions:
+#   - readability-magic-numbers: tests craft byte streams, Ogg pages, and fixed sample
+#     counts inline, where naming every literal would hurt readability more than help.
+#   - bugprone-exception-escape: each test's main() lets exceptions propagate to fail the
+#     run; that escape is intentional, not a bug.
+# All other checks (naming, modernize, the rest of bugprone, etc.) still apply.
+#
+# HeaderFilterRegex covers the test-only headers (e.g. support/ogg_mux.h) so they are
+# formally checked too. It is scoped to the test source dirs on purpose: the staged
+# upstream Opus copy lives under tests/build/, and production headers pulled in by tests
+# are checked by the src/ pass, so neither should be matched here.
+InheritParentConfig: true
+Checks: '-readability-magic-numbers,-bugprone-exception-escape'
+HeaderFilterRegex: 'tests/(support|unit|conformance)/.*\.h$'

--- a/tests/conformance/decode_vectors.cpp
+++ b/tests/conformance/decode_vectors.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-constexpr uint32_t kSampleRate = 48000;
+constexpr uint32_t SAMPLE_RATE = 48000;
 
 uint32_t read_be32(const uint8_t* p) {
     return (static_cast<uint32_t>(p[0]) << 24) | (static_cast<uint32_t>(p[1]) << 16) |
@@ -47,7 +47,7 @@ int main(int argc, char** argv) {
         return 2;
     }
 
-    const int channels = std::atoi(argv[1]);
+    const int channels = static_cast<int>(std::strtol(argv[1], nullptr, 10));
     if (channels != 1 && channels != 2) {
         std::fprintf(stderr, "channels must be 1 or 2\n");
         return 2;
@@ -65,7 +65,7 @@ int main(int argc, char** argv) {
         return 2;
     }
 
-    micro_opus::OpusPacketDecoder decoder(kSampleRate, static_cast<uint8_t>(channels));
+    micro_opus::OpusPacketDecoder decoder(SAMPLE_RATE, static_cast<uint8_t>(channels));
     std::vector<uint8_t> out(decoder.get_pcm_format().max_output_bytes());
     std::vector<uint8_t> packet;
 
@@ -88,14 +88,14 @@ int main(int argc, char** argv) {
         // outside that range means a corrupt or unsupported bitstream. The RFC vectors contain
         // neither a zero-length (DTX/PLC) packet nor an oversized one, so treat both as hard errors
         // rather than concealing or allocating a huge buffer.
-        constexpr uint32_t kMaxPacketBytes = 61440;
+        constexpr uint32_t MAX_PACKET_BYTES = 61440;
         if (len == 0) {
             std::fprintf(stderr, "Zero-length (DTX) packets are not supported by this harness\n");
             rc = 1;
             break;
         }
-        if (len > kMaxPacketBytes) {
-            std::fprintf(stderr, "Implausible payload length %u (> %u)\n", len, kMaxPacketBytes);
+        if (len > MAX_PACKET_BYTES) {
+            std::fprintf(stderr, "Implausible payload length %u (> %u)\n", len, MAX_PACKET_BYTES);
             rc = 1;
             break;
         }

--- a/tests/support/ogg_mux.h
+++ b/tests/support/ogg_mux.h
@@ -27,20 +27,20 @@
 namespace micro_opus_test {
 
 // Ogg page header flags (RFC 3533 Section 6).
-constexpr uint8_t kOggFlagContinued = 0x01;  // Page continues a packet from the previous page
-constexpr uint8_t kOggFlagBos = 0x02;        // Beginning of stream
-constexpr uint8_t kOggFlagEos = 0x04;        // End of stream
+constexpr uint8_t OGG_FLAG_CONTINUED = 0x01;  // Page continues a packet from the previous page
+constexpr uint8_t OGG_FLAG_BOS = 0x02;        // Beginning of stream
+constexpr uint8_t OGG_FLAG_EOS = 0x04;        // End of stream
 
 namespace detail {
 
 // Ogg segment-table constants.
-constexpr size_t kOggMaxSegmentSize = 255;
-constexpr size_t kOggSegmentDivisor = 254;
-constexpr size_t kOggMaxSegmentsPerPage = 255;  // Segment count is a single byte (RFC 3533 6.2)
+constexpr size_t OGG_MAX_SEGMENT_SIZE = 255;
+constexpr size_t OGG_SEGMENT_DIVISOR = 254;
+constexpr size_t OGG_MAX_SEGMENTS_PER_PAGE = 255;  // Segment count is a single byte (RFC 3533 6.2)
 
 // CRC-32 lookup table (Ogg/Ethernet polynomial 0x04C11DB7, no reflection).
 inline const uint32_t* crc_table() {
-    static const uint32_t kTable[256] = {
+    static const uint32_t TABLE[256] = {
         0x00000000, 0x04c11db7, 0x09823b6e, 0x0d4326d9, 0x130476dc, 0x17c56b6b, 0x1a864db2,
         0x1e475005, 0x2608edb8, 0x22c9f00f, 0x2f8ad6d6, 0x2b4bcb61, 0x350c9b64, 0x31cd86d3,
         0x3c8ea00a, 0x384fbdbd, 0x4c11db70, 0x48d0c6c7, 0x4593e01e, 0x4152fda9, 0x5f15adac,
@@ -78,7 +78,7 @@ inline const uint32_t* crc_table() {
         0xf9278673, 0xfde69bc4, 0x89b8fd09, 0x8d79e0be, 0x803ac667, 0x84fbdbd0, 0x9abc8bd5,
         0x9e7d9662, 0x933eb0bb, 0x97ffad0c, 0xafb010b1, 0xab710d06, 0xa6322bdf, 0xa2f33668,
         0xbcb4666d, 0xb8757bda, 0xb5365d03, 0xb1f740b4};
-    return kTable;
+    return TABLE;
 }
 
 inline uint32_t crc32(const uint8_t* buffer, size_t size) {
@@ -125,22 +125,22 @@ inline std::vector<uint8_t> make_ogg_page(uint8_t header_type, uint64_t granule_
     put_le32(page, 0);
 
     size_t num_segments =
-        (packet_data.size() + detail::kOggSegmentDivisor) / detail::kOggMaxSegmentSize;
-    if (complete_packet && (packet_data.size() % detail::kOggMaxSegmentSize == 0)) {
+        (packet_data.size() + detail::OGG_SEGMENT_DIVISOR) / detail::OGG_MAX_SEGMENT_SIZE;
+    if (complete_packet && (packet_data.size() % detail::OGG_MAX_SEGMENT_SIZE == 0)) {
         ++num_segments;  // Exact multiple of 255 needs an explicit terminating segment
     }
     // One page holds at most 255 segments (~64 KB), well above any real Opus packet. This enforces
     // the helper's single-page contract: an oversized packet fails loudly instead of truncating
     // num_segments to a uint8_t and emitting a malformed page.
-    assert(num_segments <= detail::kOggMaxSegmentsPerPage &&
+    assert(num_segments <= detail::OGG_MAX_SEGMENTS_PER_PAGE &&
            "packet too large for a single Ogg page");
     page.push_back(static_cast<uint8_t>(num_segments));
 
     size_t remaining = packet_data.size();
     for (size_t i = 0; i < num_segments; ++i) {
-        if (remaining > detail::kOggMaxSegmentSize) {
-            page.push_back(detail::kOggMaxSegmentSize);
-            remaining -= detail::kOggMaxSegmentSize;
+        if (remaining > detail::OGG_MAX_SEGMENT_SIZE) {
+            page.push_back(detail::OGG_MAX_SEGMENT_SIZE);
+            remaining -= detail::OGG_MAX_SEGMENT_SIZE;
         } else {
             page.push_back(static_cast<uint8_t>(remaining));
             remaining = 0;

--- a/tests/unit/test_chunked.cpp
+++ b/tests/unit/test_chunked.cpp
@@ -31,14 +31,14 @@
 
 namespace {
 
-constexpr uint32_t kSampleRate = 48000;
-constexpr uint8_t kChannels = 2;
-constexpr int kFrameSamples = 960;  // 20 ms @ 48 kHz, per channel
-constexpr uint16_t kPreSkip = 312;  // Standard Opus pre-skip
-constexpr int kNumPackets = 50;     // 1 s of audio
-constexpr uint32_t kSerial = 0xCAFE;
-constexpr size_t kTinyChunk = 64;  // Deliberately tiny input chunks
-constexpr size_t kMaxIterations = 1000000;
+constexpr uint32_t SAMPLE_RATE = 48000;
+constexpr uint8_t CHANNELS = 2;
+constexpr int FRAME_SAMPLES = 960;  // 20 ms @ 48 kHz, per channel
+constexpr uint16_t PRE_SKIP = 312;  // Standard Opus pre-skip
+constexpr int NUM_PACKETS = 50;     // 1 s of audio
+constexpr uint32_t SERIAL = 0xCAFE;
+constexpr size_t TINY_CHUNK = 64;  // Deliberately tiny input chunks
+constexpr size_t MAX_ITERATIONS = 1000000;
 
 int g_failures = 0;
 
@@ -49,10 +49,10 @@ void check(bool condition, const char* message) {
     }
 }
 
-// Encode kNumPackets stereo sine frames and mux them into a complete Ogg Opus byte stream.
+// Encode NUM_PACKETS stereo sine frames and mux them into a complete Ogg Opus byte stream.
 std::vector<uint8_t> build_ogg_stream() {
     int err = 0;
-    OpusEncoder* enc = opus_encoder_create(kSampleRate, kChannels, OPUS_APPLICATION_AUDIO, &err);
+    OpusEncoder* enc = opus_encoder_create(SAMPLE_RATE, CHANNELS, OPUS_APPLICATION_AUDIO, &err);
     if (enc == nullptr || err != OPUS_OK) {
         std::printf("  FAIL: opus_encoder_create returned %d\n", err);
         return {};
@@ -67,22 +67,22 @@ std::vector<uint8_t> build_ogg_stream() {
         stream.insert(stream.end(), page.begin(), page.end());
     };
     append(micro_opus_test::make_ogg_page(
-        micro_opus_test::kOggFlagBos, 0, kSerial, 0,
-        micro_opus_test::make_opus_head_family0(kChannels, kPreSkip)));
-    append(micro_opus_test::make_ogg_page(0x00, 0, kSerial, 1, micro_opus_test::make_opus_tags()));
+        micro_opus_test::OGG_FLAG_BOS, 0, SERIAL, 0,
+        micro_opus_test::make_opus_head_family0(CHANNELS, PRE_SKIP)));
+    append(micro_opus_test::make_ogg_page(0x00, 0, SERIAL, 1, micro_opus_test::make_opus_tags()));
 
-    std::vector<int16_t> pcm(static_cast<size_t>(kFrameSamples) * kChannels);
+    std::vector<int16_t> pcm(static_cast<size_t>(FRAME_SAMPLES) * CHANNELS);
     double phase = 0.0;
-    const double step = 2.0 * 3.14159265358979323846 * 440.0 / kSampleRate;
-    for (int p = 0; p < kNumPackets; ++p) {
-        for (int i = 0; i < kFrameSamples; ++i) {
+    const double step = 2.0 * 3.14159265358979323846 * 440.0 / SAMPLE_RATE;
+    for (int p = 0; p < NUM_PACKETS; ++p) {
+        for (int i = 0; i < FRAME_SAMPLES; ++i) {
             const int16_t s = static_cast<int16_t>(std::lround(std::sin(phase) * 10000.0));
-            pcm[static_cast<size_t>(i) * kChannels + 0] = s;
-            pcm[static_cast<size_t>(i) * kChannels + 1] = s;
+            pcm[static_cast<size_t>(i) * CHANNELS + 0] = s;
+            pcm[static_cast<size_t>(i) * CHANNELS + 1] = s;
             phase += step;
         }
         std::vector<uint8_t> packet(4000);
-        const int bytes = opus_encode(enc, pcm.data(), kFrameSamples, packet.data(),
+        const int bytes = opus_encode(enc, pcm.data(), FRAME_SAMPLES, packet.data(),
                                       static_cast<opus_int32>(packet.size()));
         if (bytes < 0) {
             std::printf("  FAIL: opus_encode returned %d\n", bytes);
@@ -91,9 +91,9 @@ std::vector<uint8_t> build_ogg_stream() {
         }
         packet.resize(static_cast<size_t>(bytes));
 
-        const uint64_t granule = static_cast<uint64_t>(p + 1) * kFrameSamples;
-        const uint8_t flags = (p == kNumPackets - 1) ? micro_opus_test::kOggFlagEos : 0x00;
-        append(micro_opus_test::make_ogg_page(flags, granule, kSerial, 2 + p, packet));
+        const uint64_t granule = static_cast<uint64_t>(p + 1) * FRAME_SAMPLES;
+        const uint8_t flags = (p == NUM_PACKETS - 1) ? micro_opus_test::OGG_FLAG_EOS : 0x00;
+        append(micro_opus_test::make_ogg_page(flags, granule, SERIAL, 2 + p, packet));
     }
     opus_encoder_destroy(enc);
     return stream;
@@ -109,25 +109,25 @@ int main() {
     if (stream.empty()) {
         return 1;
     }
-    std::printf("Built %d-packet stream, %zu bytes\n", kNumPackets, stream.size());
+    std::printf("Built %d-packet stream, %zu bytes\n", NUM_PACKETS, stream.size());
 
     micro_opus::OggOpusDecoder decoder;
 
-    // A sliding window that we top up kTinyChunk bytes at a time from the source stream. Sized
+    // A sliding window that we top up TINY_CHUNK bytes at a time from the source stream. Sized
     // generously so it can hold a full (multi-segment) page while still being fed 64 bytes at a
     // time. The chunk size, not the window size, is what stresses the buffering.
     std::vector<uint8_t> window(4096);
     size_t window_used = 0;
     size_t src_pos = 0;
 
-    std::vector<int16_t> pcm(static_cast<size_t>(kFrameSamples) * kChannels);
+    std::vector<int16_t> pcm(static_cast<size_t>(FRAME_SAMPLES) * CHANNELS);
 
     size_t total_samples = 0;
     size_t total_packets = 0;
     size_t iterations = 0;
 
     while (src_pos < stream.size() || window_used > 0) {
-        if (++iterations > kMaxIterations) {
+        if (++iterations > MAX_ITERATIONS) {
             std::printf("  FAIL: iteration cap hit (possible infinite loop)\n");
             return 1;
         }
@@ -135,7 +135,7 @@ int main() {
         // Top up the window with one tiny chunk.
         if (src_pos < stream.size() && window_used < window.size()) {
             const size_t space = window.size() - window_used;
-            const size_t to_copy = std::min({space, kTinyChunk, stream.size() - src_pos});
+            const size_t to_copy = std::min({space, TINY_CHUNK, stream.size() - src_pos});
             std::memcpy(window.data() + window_used, stream.data() + src_pos, to_copy);
             window_used += to_copy;
             src_pos += to_copy;
@@ -192,15 +192,15 @@ int main() {
 
     std::printf("Decoded %zu packets, %zu samples/channel\n", total_packets, total_samples);
 
-    // Pre-skip trims kPreSkip samples from the front; with a matching final granule the decoder
-    // emits (kNumPackets * kFrameSamples - kPreSkip) samples per channel.
-    const size_t expected = static_cast<size_t>(kNumPackets) * kFrameSamples - kPreSkip;
+    // Pre-skip trims PRE_SKIP samples from the front; with a matching final granule the decoder
+    // emits (NUM_PACKETS * FRAME_SAMPLES - PRE_SKIP) samples per channel.
+    const size_t expected = static_cast<size_t>(NUM_PACKETS) * FRAME_SAMPLES - PRE_SKIP;
     check(total_samples == expected, "sample count == frames*960 - pre_skip");
     if (total_samples != expected) {
         std::printf("    expected %zu, got %zu\n", expected, total_samples);
     }
-    check(decoder.get_channels() == kChannels, "decoder reports stereo");
-    check(decoder.get_sample_rate() == kSampleRate, "decoder reports 48 kHz");
+    check(decoder.get_channels() == CHANNELS, "decoder reports stereo");
+    check(decoder.get_sample_rate() == SAMPLE_RATE, "decoder reports 48 kHz");
 
     if (g_failures == 0) {
         std::printf("PASS: decoder handled 64-byte chunks correctly\n");

--- a/tests/unit/test_raw_packet.cpp
+++ b/tests/unit/test_raw_packet.cpp
@@ -26,10 +26,10 @@
 
 namespace {
 
-constexpr uint32_t kSampleRate = 48000;
-constexpr uint8_t kChannels = 2;
-constexpr int kFrameSamples = 960;  // 20 ms at 48 kHz, per channel
-constexpr size_t kFrameBytes = static_cast<size_t>(kFrameSamples) * kChannels * sizeof(int16_t);
+constexpr uint32_t SAMPLE_RATE = 48000;
+constexpr uint8_t CHANNELS = 2;
+constexpr int FRAME_SAMPLES = 960;  // 20 ms at 48 kHz, per channel
+constexpr size_t FRAME_BYTES = static_cast<size_t>(FRAME_SAMPLES) * CHANNELS * sizeof(int16_t);
 
 int g_failures = 0;
 
@@ -42,12 +42,12 @@ void check(bool condition, const char* message) {
 
 // Fill one interleaved stereo frame with a sine wave so the encoder has real signal to work with.
 void fill_sine_frame(std::vector<int16_t>& pcm, double& phase) {
-    pcm.resize(static_cast<size_t>(kFrameSamples) * kChannels);
-    const double step = 2.0 * 3.14159265358979323846 * 440.0 / kSampleRate;
-    for (int i = 0; i < kFrameSamples; ++i) {
+    pcm.resize(static_cast<size_t>(FRAME_SAMPLES) * CHANNELS);
+    const double step = 2.0 * 3.14159265358979323846 * 440.0 / SAMPLE_RATE;
+    for (int i = 0; i < FRAME_SAMPLES; ++i) {
         int16_t sample = static_cast<int16_t>(std::lround(std::sin(phase) * 12000.0));
-        pcm[static_cast<size_t>(i) * kChannels + 0] = sample;
-        pcm[static_cast<size_t>(i) * kChannels + 1] = sample;
+        pcm[static_cast<size_t>(i) * CHANNELS + 0] = sample;
+        pcm[static_cast<size_t>(i) * CHANNELS + 1] = sample;
         phase += step;
     }
 }
@@ -60,20 +60,20 @@ int main() {
     // --- Encode a handful of frames into raw Opus packets ---
     int enc_error = 0;
     OpusEncoder* encoder =
-        opus_encoder_create(kSampleRate, kChannels, OPUS_APPLICATION_AUDIO, &enc_error);
+        opus_encoder_create(SAMPLE_RATE, CHANNELS, OPUS_APPLICATION_AUDIO, &enc_error);
     if (encoder == nullptr || enc_error != OPUS_OK) {
         std::printf("  FAIL: could not create encoder (%d)\n", enc_error);
         return 1;
     }
 
-    constexpr int kNumFrames = 10;
+    constexpr int NUM_FRAMES = 10;
     std::vector<std::vector<uint8_t>> packets;
     std::vector<int16_t> pcm;
     double phase = 0.0;
-    for (int f = 0; f < kNumFrames; ++f) {
+    for (int f = 0; f < NUM_FRAMES; ++f) {
         fill_sine_frame(pcm, phase);
         std::vector<uint8_t> packet(4000);
-        int bytes = opus_encode(encoder, pcm.data(), kFrameSamples, packet.data(),
+        int bytes = opus_encode(encoder, pcm.data(), FRAME_SAMPLES, packet.data(),
                                 static_cast<opus_int32>(packet.size()));
         if (bytes < 0) {
             std::printf("  FAIL: opus_encode returned %d\n", bytes);
@@ -86,27 +86,27 @@ int main() {
     opus_encoder_destroy(encoder);
 
     // --- Decode the packets and verify ---
-    micro_opus::OpusPacketDecoder decoder(kSampleRate, kChannels);
+    micro_opus::OpusPacketDecoder decoder(SAMPLE_RATE, CHANNELS);
 
     // PcmFormat is valid immediately (pre-framed: format comes from the constructor).
     const auto& fmt = decoder.get_pcm_format();
     check(fmt.is_valid(), "format valid before first decode");
-    check(fmt.sample_rate() == kSampleRate, "format sample_rate");
-    check(fmt.num_channels() == kChannels, "format num_channels");
+    check(fmt.sample_rate() == SAMPLE_RATE, "format sample_rate");
+    check(fmt.num_channels() == CHANNELS, "format num_channels");
     check(fmt.bytes_per_sample() == 2, "format bytes_per_sample");
     // max_output_bytes is the 120 ms upper bound: 48000/1000*120 = 5760 samples/ch.
-    check(fmt.max_output_bytes() == 5760u * kChannels * 2u, "format max_output_bytes");
+    check(fmt.max_output_bytes() == 5760U * CHANNELS * 2U, "format max_output_bytes");
 
     // int16_t output buffer: naturally aligned for the decoder's 16-bit PCM writes. The API stays
     // byte-oriented, so cast to uint8_t* and pass the size in bytes at each call site.
     std::vector<int16_t> out(fmt.max_output_bytes() / sizeof(int16_t));
-    for (size_t i = 0; i < packets.size(); ++i) {
+    for (const auto& packet : packets) {
         size_t bytes_written = 0;
-        auto result = decoder.decode(packets[i].data(), packets[i].size(),
-                                     reinterpret_cast<uint8_t*>(out.data()),
-                                     out.size() * sizeof(int16_t), bytes_written);
+        auto result =
+            decoder.decode(packet.data(), packet.size(), reinterpret_cast<uint8_t*>(out.data()),
+                           out.size() * sizeof(int16_t), bytes_written);
         check(result == micro_opus::OPUS_PACKET_DECODER_SUCCESS, "decode succeeds");
-        check(bytes_written == kFrameBytes, "decode bytes_written == one 20 ms stereo frame");
+        check(bytes_written == FRAME_BYTES, "decode bytes_written == one 20 ms stereo frame");
     }
 
     // --- Recoverable OUTPUT_BUFFER_TOO_SMALL: tiny buffer, then grow and retry ---
@@ -120,14 +120,14 @@ int main() {
               "small buffer => OUTPUT_BUFFER_TOO_SMALL");
         check(bytes_written == 0, "failed decode clears bytes_written");
         size_t needed = decoder.get_required_output_bytes();
-        check(needed == kFrameBytes, "get_required_output_bytes reports exact size");
+        check(needed == FRAME_BYTES, "get_required_output_bytes reports exact size");
 
         std::vector<int16_t> grown(needed / sizeof(int16_t));
         result = decoder.decode(packets[0].data(), packets[0].size(),
                                 reinterpret_cast<uint8_t*>(grown.data()),
                                 grown.size() * sizeof(int16_t), bytes_written);
         check(result == micro_opus::OPUS_PACKET_DECODER_SUCCESS, "retry after grow succeeds");
-        check(bytes_written == kFrameBytes, "retry produces full frame");
+        check(bytes_written == FRAME_BYTES, "retry produces full frame");
     }
 
     // --- Packet-loss concealment ---
@@ -135,9 +135,9 @@ int main() {
         size_t bytes_written = 0;
         auto result =
             decoder.conceal_loss(reinterpret_cast<uint8_t*>(out.data()),
-                                 out.size() * sizeof(int16_t), kFrameSamples, bytes_written);
+                                 out.size() * sizeof(int16_t), FRAME_SAMPLES, bytes_written);
         check(result == micro_opus::OPUS_PACKET_DECODER_SUCCESS, "conceal_loss succeeds");
-        check(bytes_written == kFrameBytes, "conceal_loss fills one frame");
+        check(bytes_written == FRAME_BYTES, "conceal_loss fills one frame");
     }
 
     // --- Invalid arguments ---
@@ -160,13 +160,13 @@ int main() {
     {
         decoder.reset();
         check(decoder.get_required_output_bytes() == 0, "reset clears required_output_bytes");
-        check(decoder.get_pcm_format().sample_rate() == kSampleRate, "reset preserves config");
+        check(decoder.get_pcm_format().sample_rate() == SAMPLE_RATE, "reset preserves config");
         size_t bytes_written = 0;
         auto result = decoder.decode(packets[0].data(), packets[0].size(),
                                      reinterpret_cast<uint8_t*>(out.data()),
                                      out.size() * sizeof(int16_t), bytes_written);
         check(result == micro_opus::OPUS_PACKET_DECODER_SUCCESS, "decode works after reset");
-        check(bytes_written == kFrameBytes, "post-reset frame size");
+        check(bytes_written == FRAME_BYTES, "post-reset frame size");
     }
 
     if (g_failures == 0) {

--- a/tests/unit/test_silent_channels.cpp
+++ b/tests/unit/test_silent_channels.cpp
@@ -27,13 +27,13 @@
 
 namespace {
 
-constexpr uint32_t kSerialNumber = 12345;
-constexpr uint32_t kFrameSize = 960;  // 20 ms @ 48 kHz
+constexpr uint32_t SERIAL_NUMBER = 12345;
+constexpr uint32_t FRAME_SIZE = 960;  // 20 ms @ 48 kHz
 
-using micro_opus_test::kOggFlagBos;
 using micro_opus_test::make_ogg_page;
 using micro_opus_test::make_opus_head_family1;
 using micro_opus_test::make_opus_tags;
+using micro_opus_test::OGG_FLAG_BOS;
 
 // Encode one 20 ms stereo frame of silence with libopus. The OpusHead below declares a single
 // coupled (stereo) stream, so its packets must be well-formed stereo Opus packets. Returns empty on
@@ -44,9 +44,9 @@ std::vector<uint8_t> make_silent_stereo_packet() {
     if (enc == nullptr || err != OPUS_OK) {
         return {};
     }
-    const std::vector<int16_t> silence(static_cast<size_t>(kFrameSize) * 2, 0);
+    const std::vector<int16_t> silence(static_cast<size_t>(FRAME_SIZE) * 2, 0);
     std::vector<uint8_t> packet(4000);
-    const int bytes = opus_encode(enc, silence.data(), static_cast<int>(kFrameSize), packet.data(),
+    const int bytes = opus_encode(enc, silence.data(), static_cast<int>(FRAME_SIZE), packet.data(),
                                   static_cast<opus_int32>(packet.size()));
     opus_encoder_destroy(enc);
     if (bytes < 0) {
@@ -76,16 +76,16 @@ int main() {
     auto append = [&stream](const std::vector<uint8_t>& page) {
         stream.insert(stream.end(), page.begin(), page.end());
     };
-    append(make_ogg_page(kOggFlagBos, 0, kSerialNumber, 0, opus_head));
-    append(make_ogg_page(0x00, 0, kSerialNumber, 1, make_opus_tags()));
-    append(make_ogg_page(0x00, kFrameSize, kSerialNumber, 2, audio_packet));
+    append(make_ogg_page(OGG_FLAG_BOS, 0, SERIAL_NUMBER, 0, opus_head));
+    append(make_ogg_page(0x00, 0, SERIAL_NUMBER, 1, make_opus_tags()));
+    append(make_ogg_page(0x00, FRAME_SIZE, SERIAL_NUMBER, 2, audio_packet));
 
     std::printf("Created test stream: 3 channels [0,1,255], 1 coupled stereo stream, %zu bytes\n\n",
                 stream.size());
 
     micro_opus::OggOpusDecoder decoder;
-    constexpr size_t kNumChannels = 3;
-    int16_t pcm_buffer[kFrameSize * kNumChannels];
+    constexpr size_t NUM_CHANNELS = 3;
+    int16_t pcm_buffer[FRAME_SIZE * NUM_CHANNELS];
     size_t consumed = 0;
     size_t samples_decoded = 0;
     size_t total_consumed = 0;
@@ -111,13 +111,13 @@ int main() {
             std::printf("Decoded %zu samples/channel, %u channels @ %u Hz\n", samples_decoded,
                         decoder.get_channels(), decoder.get_sample_rate());
 
-            if (decoder.get_channels() != kNumChannels) {
+            if (decoder.get_channels() != NUM_CHANNELS) {
                 std::printf("ERROR: Expected 3 channels, got %u\n", decoder.get_channels());
                 return 1;
             }
 
             for (size_t i = 0; i < samples_decoded; ++i) {
-                const int16_t center = pcm_buffer[i * kNumChannels + 2];
+                const int16_t center = pcm_buffer[i * NUM_CHANNELS + 2];
                 if (center != 0) {
                     std::printf("ERROR: Silent channel not silent at sample %zu: %d\n", i, center);
                     return 1;


### PR DESCRIPTION
Test sources used Google-style k-prefixed constants and were excluded from clang-tidy. Rename the constants to the project's UPPER_CASE convention (k-prefix only remains in qemu_opus_test.cpp's local const array, lowercased per the config) and wire the test sources into the linter.

- Add tests/.clang-tidy: inherits the root config, disables readability-magic-numbers and bugprone-exception-escape, and scopes HeaderFilterRegex to the test header dirs.
- script/clang-tidy.sh: run a second pass over tests/unit and tests/conformance against tests/build's compile database.
- Fix findings the new pass surfaced: lowercase literal suffixes, an index loop replaced with a range-based for, and atoi -> strtol.