### PR TITLE
Set read-only permissions for publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,8 @@ jobs:
     name: Publish to PlatformIO
     runs-on: ubuntu-latest
     environment: platformio
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,13 +4,16 @@ on:
   release:
     types: [published]
 
+# Least privilege: jobs only read the repo to check out and publish. Jobs that need more should
+# add a narrower job-level permissions block rather than widening this default.
+permissions:
+  contents: read
+
 jobs:
   publish-platformio:
     name: Publish to PlatformIO
     runs-on: ubuntu-latest
     environment: platformio
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -31,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: espressif
     permissions:
+      contents: read
       id-token: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
Potential fix for [https://github.com/esphome-libs/micro-opus/security/code-scanning/1](https://github.com/esphome-libs/micro-opus/security/code-scanning/1)

Add an explicit `permissions` block to the `publish-platformio` job in `.github/workflows/publish.yml`, scoped to the minimal permission needed: `contents: read`.

Best single fix without changing functionality:
- Edit `.github/workflows/publish.yml`
- In job `publish-platformio` (right after `environment` is a clear location), add:
  - `permissions:`
  - `contents: read`

This preserves current behavior while enforcing least privilege for `GITHUB_TOKEN` in that job. No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
