### PR TITLE
Make clang-tidy lint enforcing and cover src/ headers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -32,7 +32,6 @@ Checks: >
   readability-delete-null-pointer,
   readability-duplicate-include,
   readability-else-after-return,
-  readability-function-cognitive-complexity,
   readability-identifier-naming,
   readability-implicit-bool-conversion,
   readability-inconsistent-declaration-parameter-name,
@@ -53,9 +52,12 @@ Checks: >
   readability-string-compare,
   readability-uppercase-literal-suffix
 
-WarningsAsErrors: ''
+WarningsAsErrors: '*'
 
-HeaderFilterRegex: 'include/micro_opus/.*\.h$'
+# Lint first-party headers under include/, all of src/, and the host example's own
+# headers. The host_examples/[^/]+/[^/]+ term stops at depth two so the build-tree
+# headers under host_examples/*/build/ (and the staged upstream Opus copy) are not linted.
+HeaderFilterRegex: '((include/micro_opus|src)/.*|host_examples/[^/]+/[^/]+)\.h$'
 
 CheckOptions:
   # Naming conventions matching existing code style
@@ -91,12 +93,6 @@ CheckOptions:
     value: lower_case
   - key: readability-identifier-naming.MacroDefinitionCase
     value: UPPER_CASE
-
-  # Complexity thresholds (reasonable for embedded)
-  - key: readability-function-cognitive-complexity.Threshold
-    value: '50'
-  - key: readability-function-cognitive-complexity.IgnoreMacros
-    value: 'true'
 
   # Magic numbers - allow common values used in bit manipulation and byte handling
   # Includes: small indices (0-7), bit shifts (8,16,24,32,40,48,56), byte values (255,256)

--- a/host_examples/opus_to_wav/opus_to_wav.cpp
+++ b/host_examples/opus_to_wav/opus_to_wav.cpp
@@ -127,7 +127,7 @@ int main(int argc, char* argv[]) {
                     // Create WAV writer with decoder's format
                     wav_writer = new WavWriter(output_file, sample_rate, channels, 16);
 
-                    if (!wav_writer->isOpen()) {
+                    if (!wav_writer->is_open()) {
                         std::cerr << "Error: Could not create output file: " << output_file << "\n";
                         delete wav_writer;
                         return 1;
@@ -165,7 +165,7 @@ int main(int argc, char* argv[]) {
 
                     // Write decoded samples to WAV file
                     if (wav_writer) {
-                        if (!wav_writer->writeSamples(pcm_buffer.data(), samples)) {
+                        if (!wav_writer->write_samples(pcm_buffer.data(), samples)) {
                             std::cerr << "Error: Failed to write samples to WAV file\n";
                             delete wav_writer;
                             return 1;
@@ -190,9 +190,9 @@ int main(int argc, char* argv[]) {
                       << (total_bytes_consumed / (total_packets > 0 ? total_packets : 1)) << "\n";
             std::cout << "Total packets decoded: " << total_packets << " (" << audio_packets
                       << " audio packets)\n";
-            std::cout << "Total samples written: " << wav_writer->getSamplesWritten() << "\n";
+            std::cout << "Total samples written: " << wav_writer->get_samples_written() << "\n";
             std::cout << "Duration: "
-                      << (wav_writer->getSamplesWritten() /
+                      << (wav_writer->get_samples_written() /
                           static_cast<double>(decoder.get_sample_rate()))
                       << " seconds\n";
             std::cout << "Output file: " << output_file << "\n";

--- a/host_examples/opus_to_wav/wav_writer.cpp
+++ b/host_examples/opus_to_wav/wav_writer.cpp
@@ -51,22 +51,21 @@ WavWriter::WavWriter(const std::string& filename, uint32_t sample_rate, uint16_t
     : file_(fopen(filename.c_str(), "wb")),
       sample_rate_(sample_rate),
       num_channels_(num_channels),
-      bits_per_sample_(bits_per_sample),
-      samples_written_(0) {
+      bits_per_sample_(bits_per_sample) {
     if (file_) {
-        writeHeader();
+        write_header();
     }
 }
 
 WavWriter::~WavWriter() {
     if (file_) {
-        updateHeader();
+        update_header();
         fclose(file_);
         file_ = nullptr;
     }
 }
 
-void WavWriter::writeHeader() {
+void WavWriter::write_header() {
     RIFFHeader riff{};
     memcpy(riff.chunk_id, "RIFF", 4);
     riff.chunk_size = 0;  // Will update later
@@ -91,7 +90,7 @@ void WavWriter::writeHeader() {
     fwrite(&data, sizeof(data), 1, file_);
 }
 
-void WavWriter::updateHeader() {
+void WavWriter::update_header() {
     if (!file_) {
         return;
     }
@@ -111,7 +110,7 @@ void WavWriter::updateHeader() {
     fseek(file_, 0, SEEK_END);
 }
 
-bool WavWriter::writeSamples(const int16_t* samples, size_t num_samples) {
+bool WavWriter::write_samples(const int16_t* samples, size_t num_samples) {
     if (!file_ || !samples || num_samples == 0) {
         return false;
     }

--- a/host_examples/opus_to_wav/wav_writer.h
+++ b/host_examples/opus_to_wav/wav_writer.h
@@ -48,14 +48,14 @@ public:
      * @param num_samples Number of samples (per channel)
      * @return true if successful, false on error
      */
-    bool writeSamples(const int16_t* samples, size_t num_samples);
+    bool write_samples(const int16_t* samples, size_t num_samples);
 
     /**
      * @brief Check if the WAV file is open and ready
      *
      * @return true if file is open
      */
-    bool isOpen() const {
+    bool is_open() const {
         return file_ != nullptr;
     }
 
@@ -64,7 +64,7 @@ public:
      *
      * @return Total samples written (per channel)
      */
-    uint64_t getSamplesWritten() const {
+    uint64_t get_samples_written() const {
         return samples_written_;
     }
 
@@ -73,14 +73,14 @@ private:
     WavWriter(const WavWriter&) = delete;
     WavWriter& operator=(const WavWriter&) = delete;
 
-    void writeHeader();
-    void updateHeader();
+    void write_header();
+    void update_header();
 
     FILE* file_;
     uint32_t sample_rate_;
     uint16_t num_channels_;
     uint16_t bits_per_sample_;
-    uint64_t samples_written_;
+    uint64_t samples_written_{0};
 };
 
 #endif  // WAV_WRITER_HPP

--- a/include/micro_opus/opus_packet_decoder.h
+++ b/include/micro_opus/opus_packet_decoder.h
@@ -92,7 +92,10 @@ public:
     /// output_size_bytes.
     /// @return Output buffer size in bytes (all channels)
     uint32_t max_output_bytes() const {
-        return (this->sample_rate_ / 1000U * 120U) * this->num_channels_ * this->bytes_per_sample();
+        constexpr uint32_t MS_PER_SECOND = 1000U;
+        constexpr uint32_t MAX_PACKET_DURATION_MS = 120U;  // Opus' largest frame duration
+        return (this->sample_rate_ / MS_PER_SECOND * MAX_PACKET_DURATION_MS) * this->num_channels_ *
+               this->bytes_per_sample();
     }
     /// @brief Number of output channels (1 = mono, 2 = stereo)
     /// @return Output channel count
@@ -173,6 +176,9 @@ public:
  */
 class OpusPacketDecoder {
 public:
+    /// @brief Default output sample rate in Hz (the native Opus rate)
+    static constexpr uint32_t DEFAULT_SAMPLE_RATE = 48000;
+
     // ========================================
     // Lifecycle
     // ========================================
@@ -187,7 +193,7 @@ public:
     ///                    48000 (the rates Opus can decode to); other values are rejected on the
     ///                    first decode() call. Default 48000 (native Opus rate).
     /// @param channels Output channel count: 1 (mono) or 2 (stereo). Default 2.
-    explicit OpusPacketDecoder(uint32_t sample_rate = 48000, uint8_t channels = 2);
+    explicit OpusPacketDecoder(uint32_t sample_rate = DEFAULT_SAMPLE_RATE, uint8_t channels = 2);
 
     /// @brief Destroy the decoder and free the libopus decoder state
     ~OpusPacketDecoder();

--- a/script/clang-tidy.sh
+++ b/script/clang-tidy.sh
@@ -58,8 +58,14 @@ if [ -z "$SOURCES" ]; then
 fi
 
 # Host test sources use their own compile database (tests/build). They inherit every rule from the
-# root .clang-tidy except readability-magic-numbers, which tests/.clang-tidy disables. qemu/ is an
-# ESP-IDF app and can't be checked on the host, so it is left out.
+# root .clang-tidy except two that tests/.clang-tidy disables: readability-magic-numbers (tests
+# craft raw byte literals where naming each value would hurt readability) and bugprone-exception-
+# escape (each test's main() intentionally lets exceptions propagate to fail the run). The find
+# targets unit/ and conformance/ specifically; two other tests/ subdirs are left out on purpose:
+#   - qemu/ is an ESP-IDF app and can't be checked on the host.
+#   - tools/ (measure_zerocopy) only compiles under -DBUILD_MEASURE_TOOLS=ON, which instruments the
+#     library with MICRO_OGG_DEMUXER_DEBUG and so is absent from the default tests compile DB; it
+#     would need a dedicated debug build dir to lint. (support/ is headers-only, covered by the filter.)
 TEST_BUILD_DIR="${ROOT_DIR}/tests/build"
 TEST_SOURCES=$(find "$ROOT_DIR/tests/unit" "$ROOT_DIR/tests/conformance" \
     -name '*.cpp' -print 2>/dev/null || true)

--- a/src/opus_header.h
+++ b/src/opus_header.h
@@ -19,8 +19,8 @@
 #ifndef OPUS_HEADER_H
 #define OPUS_HEADER_H
 
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 
 namespace micro_opus {
 
@@ -44,7 +44,7 @@ struct OpusHead {
 /**
  * @brief Result codes for header parsing
  */
-enum OpusHeaderResult {
+enum OpusHeaderResult : int8_t {
     OPUS_HEADER_OK = 0,
     OPUS_HEADER_INVALID_MAGIC = -1,
     OPUS_HEADER_INVALID_VERSION = -2,


### PR DESCRIPTION
WarningsAsErrors was empty, so clang-tidy exited 0 on every finding and the CI lint job never failed. HeaderFilterRegex matched only include/, leaving src/ internal headers and the host example's headers unchecked.

Set WarningsAsErrors to '*' and widen HeaderFilterRegex to src/ and the host example sources. Drop readability-function-cognitive-complexity so the check list matches micro-vorbis, micro-mp3, and micro-flac.

Turning the gate on exposed existing findings, now fixed:
- opus_packet_decoder.h: name the 1000/120/48000 literals
- opus_header.h: give OpusHeaderResult an int8_t base, switch to <cstdint>
- wav_writer: rename methods to snake_case, default-init samples_written_

Also document the tests/tools, qemu/, and examples/ lint exclusions in clang-tidy.sh.