### PR TITLE
Use selective shallow submodule init in CI and publish jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,10 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          submodules: recursive
+          submodules: false
+
+      - name: Initialize library submodules
+        run: git submodule update --init --depth 1 lib/opus lib/micro-ogg-demuxer
 
       - name: Install clang-tidy
         run: |
@@ -73,7 +76,10 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          submodules: recursive
+          submodules: false
+
+      - name: Initialize library submodules
+        run: git submodule update --init --depth 1 lib/opus lib/micro-ogg-demuxer
 
       - name: Install ccache
         run: sudo apt-get update && sudo apt-get install -y ccache
@@ -110,7 +116,10 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          submodules: recursive
+          submodules: false
+
+      - name: Initialize library submodules
+        run: git submodule update --init --depth 1 lib/opus lib/micro-ogg-demuxer
 
       - name: Install ccache
         run: sudo apt-get update && sudo apt-get install -y ccache
@@ -144,7 +153,10 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          submodules: recursive
+          submodules: false
+
+      - name: Initialize library submodules
+        run: git submodule update --init --depth 1 lib/opus lib/micro-ogg-demuxer
 
       - name: Install ccache
         run: sudo apt-get update && sudo apt-get install -y ccache
@@ -312,7 +324,10 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          submodules: recursive
+          submodules: false
+
+      - name: Initialize library submodules
+        run: git submodule update --init --depth 1 lib/opus lib/micro-ogg-demuxer
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,9 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          submodules: recursive
+          submodules: false
+      - name: Initialize library submodules
+        run: git submodule update --init --depth 1 lib/opus lib/micro-ogg-demuxer
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -86,7 +88,9 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          submodules: recursive
+          submodules: false
+      - name: Initialize library submodules
+        run: git submodule update --init --depth 1 lib/opus lib/micro-ogg-demuxer
       - name: Publish package
         uses: espressif/upload-components-ci-action@2ce17d73e35473317c1419dbd4f007aacb593040 # v2.2.1
         with:


### PR DESCRIPTION
Replace submodules: recursive in the host CI and publish jobs with submodules: false plus an explicit shallow init of lib/opus and lib/micro-ogg-demuxer, the pattern the cross-qemu job already uses. Avoids fetching full submodule history.

This approach matches other microCodec libraries.