### PR TITLE
Set project() VERSION in host CMakeLists and bump it on release

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           sed -i "s/\"version\": .*/\"version\": \"${{ steps.drafter.outputs.resolved_version }}\",/g" library.json
           sed -i "s/version: .*/version: \"${{ steps.drafter.outputs.resolved_version }}\"/g" idf_component.yml
+          sed -i "s/project(micro_opus VERSION .* LANGUAGES/project(micro_opus VERSION ${{ steps.drafter.outputs.resolved_version }} LANGUAGES/g" CMakeLists.txt
 
       - name: Commit changes
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ if(ESP_IDF_BUILD)
 
 else()
     cmake_minimum_required(VERSION 3.16)
-    project(micro_opus C CXX)
+    project(micro_opus VERSION 0.5.0 LANGUAGES C CXX)
 
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/host.cmake)
 


### PR DESCRIPTION
The host project() carried no VERSION, so the version lived only in library.json and idf_component.yml. Add VERSION 0.5.0 (plus the LANGUAGES keyword) and a third sed in release-drafter so all three files stay in sync on each bump, matching microFLAC and microVorbis.