### PR TITLE
Enforce -Werror on our own sources (wrapper and example)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Configure CMake
         run: >
-          cmake -B build
+          cmake -B build -DENABLE_WERROR=ON
           -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           host_examples/opus_to_wav
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,10 @@ else()
 
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/host.cmake)
 
+    # Treat warnings as errors (off by default; CI sets -DENABLE_WERROR=ON). Applied only to our own
+    # wrapper sources and the host example, never to the bundled upstream Opus C.
+    option(ENABLE_WERROR "Treat warnings as errors" OFF)
+
     # Option for memory allocation mode
     set(OPUS_ALLOCATION_MODE "THREADSAFE_PSEUDOSTACK" CACHE STRING "Memory allocation mode")
     set_property(CACHE OPUS_ALLOCATION_MODE PROPERTY STRINGS
@@ -141,5 +145,25 @@ else()
 
     # Apply host configuration
     opus_configure_host(micro_opus ${CMAKE_CURRENT_SOURCE_DIR} ${OPUS_STAGED_DIR})
+
+    # Strict warnings for our own wrapper sources only. The bundled upstream Opus C is not clean
+    # under this set and is never edited here, so it keeps the relaxed flags from
+    # opus_set_optimization_flags(); scoping these per-source confines them to src/. ENABLE_WERROR
+    # makes them fatal in CI. Mirrors the warning set used across the micro-* libraries.
+    set(MICRO_OPUS_WRAPPER_WARNINGS
+        -Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wsign-conversion -Wdouble-promotion
+        -Wformat=2 -Wimplicit-fallthrough)
+    if(ENABLE_WERROR)
+        list(APPEND MICRO_OPUS_WRAPPER_WARNINGS -Werror)
+        # These sources build at -O2 (above), where GCC's -Wmaybe-uninitialized is
+        # false-positive-prone, so keep it non-fatal under GCC (matching opus_set_optimization_flags);
+        # a definite -Wuninitialized still errors. Clang has no such warning and would reject the
+        # flag under -Werror, so gate it on GCC.
+        if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+            list(APPEND MICRO_OPUS_WRAPPER_WARNINGS -Wno-error=maybe-uninitialized)
+        endif()
+    endif()
+    set_source_files_properties(${OGG_OPUS_SOURCES} PROPERTIES
+        COMPILE_OPTIONS "${MICRO_OPUS_WRAPPER_WARNINGS}")
 
 endif()

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -40,11 +40,13 @@ function(opus_set_optimization_flags TARGET)
         -O2
         -ffunction-sections
         -fdata-sections
-        # GCC 14+ emits a false-positive -Wmaybe-uninitialized in upstream
-        # silk/NLSF2A.c: cos_LSF_QA[] is filled via a permutation table the
-        # analyzer can't reason about. Demote to a non-fatal warning so
-        # consumers building with -Werror=all (e.g. ESP-IDF defaults) don't
-        # break. Remove once upstream xiph/opus silences this.
-        -Wno-error=maybe-uninitialized
     )
+    # GCC 14+ emits a false-positive -Wmaybe-uninitialized in upstream silk/NLSF2A.c: cos_LSF_QA[]
+    # is filled via a permutation table the analyzer can't reason about. Demote it to non-fatal so
+    # consumers building with -Werror=all (e.g. ESP-IDF defaults) don't break. GCC-only: Clang has
+    # no such warning and would reject the flag as an unknown-warning-option under -Werror. Remove
+    # once upstream xiph/opus silences this.
+    if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        target_compile_options(${TARGET} PRIVATE -Wno-error=maybe-uninitialized)
+    endif()
 endfunction()

--- a/host_examples/opus_to_wav/CMakeLists.txt
+++ b/host_examples/opus_to_wav/CMakeLists.txt
@@ -39,6 +39,24 @@ target_link_libraries(opus_to_wav PRIVATE
     micro_opus
 )
 
+# Strict warnings for the example's own sources (the micro_opus library applies its own per-source
+# flags). ENABLE_WERROR, declared in the top-level CMakeLists added above, makes them fatal in CI.
+target_compile_options(opus_to_wav PRIVATE
+    -Wall
+    -Wextra
+    -Wpedantic
+    -Wshadow
+    -Wconversion
+    -Wsign-conversion
+    -Wdouble-promotion
+    -Wformat=2
+    -Wimplicit-fallthrough
+    $<$<BOOL:${ENABLE_WERROR}>:-Werror>
+    # GCC's -Wmaybe-uninitialized is false-positive-prone under optimization; keep it non-fatal
+    # under GCC (matching the wrapper sources). Clang lacks the warning and would reject the flag.
+    $<$<AND:$<BOOL:${ENABLE_WERROR}>,$<CXX_COMPILER_ID:GNU>>:-Wno-error=maybe-uninitialized>
+)
+
 # Install target
 install(TARGETS opus_to_wav
     RUNTIME DESTINATION bin

--- a/host_examples/opus_to_wav/opus_to_wav.cpp
+++ b/host_examples/opus_to_wav/opus_to_wav.cpp
@@ -93,7 +93,7 @@ int main(int argc, char* argv[]) {
                 break;  // EOF reached
             }
 
-            total_bytes_read += bytes_read;
+            total_bytes_read += static_cast<size_t>(bytes_read);
 
             // Decode from this chunk - decoder may need multiple calls per chunk
             size_t chunk_offset = 0;
@@ -104,7 +104,8 @@ int main(int argc, char* argv[]) {
                 decode_calls++;
 
                 micro_opus::OggOpusResult result =
-                    decoder.decode(input_buffer.data() + chunk_offset, bytes_read - chunk_offset,
+                    decoder.decode(input_buffer.data() + chunk_offset,
+                                   static_cast<size_t>(bytes_read) - chunk_offset,
                                    reinterpret_cast<uint8_t*>(pcm_buffer.data()),
                                    pcm_buffer.size() * sizeof(int16_t), consumed, samples);
 
@@ -192,7 +193,7 @@ int main(int argc, char* argv[]) {
                       << " audio packets)\n";
             std::cout << "Total samples written: " << wav_writer->get_samples_written() << "\n";
             std::cout << "Duration: "
-                      << (wav_writer->get_samples_written() /
+                      << (static_cast<double>(wav_writer->get_samples_written()) /
                           static_cast<double>(decoder.get_sample_rate()))
                       << " seconds\n";
             std::cout << "Output file: " << output_file << "\n";

--- a/host_examples/opus_to_wav/wav_writer.cpp
+++ b/host_examples/opus_to_wav/wav_writer.cpp
@@ -95,8 +95,15 @@ void WavWriter::update_header() {
         return;
     }
 
-    uint32_t data_size =
-        static_cast<uint32_t>(samples_written_ * num_channels_ * (bits_per_sample_ / 8));
+    // WAV's RIFF chunk sizes are 32-bit, so the format cannot represent payloads >4 GiB. Compute in
+    // 64-bit and clamp on overflow so the header is wrong-but-bounded with a warning, rather than
+    // silently wrapping to a garbage size.
+    uint64_t data_size_full = samples_written_ * num_channels_ * (bits_per_sample_ / 8);
+    if (data_size_full + WAV_HEADER_SIZE > UINT32_MAX) {
+        fprintf(stderr, "warning: output exceeds WAV's 4 GiB limit; header sizes clamped\n");
+        data_size_full = UINT32_MAX - WAV_HEADER_SIZE;
+    }
+    uint32_t data_size = static_cast<uint32_t>(data_size_full);
     uint32_t file_size = data_size + WAV_HEADER_SIZE;
 
     // Update RIFF chunk size

--- a/host_examples/opus_to_wav/wav_writer.cpp
+++ b/host_examples/opus_to_wav/wav_writer.cpp
@@ -95,7 +95,8 @@ void WavWriter::update_header() {
         return;
     }
 
-    uint32_t data_size = samples_written_ * num_channels_ * (bits_per_sample_ / 8);
+    uint32_t data_size =
+        static_cast<uint32_t>(samples_written_ * num_channels_ * (bits_per_sample_ / 8));
     uint32_t file_size = data_size + WAV_HEADER_SIZE;
 
     // Update RIFF chunk size

--- a/src/ogg_opus_decoder.cpp
+++ b/src/ogg_opus_decoder.cpp
@@ -135,7 +135,7 @@ OggOpusResult OggOpusDecoder::validate_granule_position(int64_t granule_pos, siz
         }
 
         if (first_audio_page_samples_ >= 0) {
-            first_audio_page_samples_ += decoded_samples;
+            first_audio_page_samples_ += static_cast<int64_t>(decoded_samples);
 
             if (is_last_on_page) {
                 if (!is_eos && granule_pos < first_audio_page_samples_) {

--- a/src/ogg_opus_decoder.cpp
+++ b/src/ogg_opus_decoder.cpp
@@ -166,8 +166,8 @@ OggOpusResult OggOpusDecoder::create_opus_decoder(uint8_t output_channels) {
         packet_decoder_->set_output_gain(opus_head_->output_gain);
     } else {
         opus_ms_decoder_ = opus_multistream_decoder_create(
-            sample_rate_, output_channels, opus_head_->stream_count, opus_head_->coupled_count,
-            opus_head_->channel_mapping_table, &error);
+            static_cast<opus_int32>(sample_rate_), output_channels, opus_head_->stream_count,
+            opus_head_->coupled_count, opus_head_->channel_mapping_table, &error);
 
         if (error != OPUS_OK || !opus_ms_decoder_) {
             return OGG_OPUS_ALLOCATION_FAILED;

--- a/src/opus_header.cpp
+++ b/src/opus_header.cpp
@@ -25,11 +25,12 @@ namespace micro_opus {
 namespace {
 // Little-endian helpers for Opus header parsing
 inline uint16_t read_le16(const uint8_t* p) {
-    return p[0] | (p[1] << 8);
+    return static_cast<uint16_t>(p[0] | (p[1] << 8));
 }
 
 inline uint32_t read_le32(const uint8_t* p) {
-    return p[0] | (p[1] << 8) | (p[2] << 16) | (p[3] << 24);
+    return static_cast<uint32_t>(p[0]) | (static_cast<uint32_t>(p[1]) << 8) |
+           (static_cast<uint32_t>(p[2]) << 16) | (static_cast<uint32_t>(p[3]) << 24);
 }
 
 // RFC 7845: Opus magic signature lengths
@@ -83,7 +84,7 @@ OpusHeaderResult parse_opus_head(const uint8_t* packet, size_t packet_len, OpusH
     head.channel_count = packet[OPUS_MAGIC_SIGNATURE_SIZE + 1];
     head.pre_skip = read_le16(packet + OPUS_MAGIC_SIGNATURE_SIZE + 2);
     head.input_sample_rate = read_le32(packet + OPUS_MAGIC_SIGNATURE_SIZE + 4);
-    head.output_gain = (int16_t)read_le16(packet + OPUS_MAGIC_SIGNATURE_SIZE + 8);
+    head.output_gain = static_cast<int16_t>(read_le16(packet + OPUS_MAGIC_SIGNATURE_SIZE + 8));
     head.channel_mapping = packet[OPUS_MAGIC_SIGNATURE_SIZE + OPUS_HEAD_CHANNEL_MAPPING_OFFSET];
 
     // Validate version


### PR DESCRIPTION
Add an ENABLE_WERROR option and apply a strict warning set plus -Werror to our own code only: the src/ wrapper (per-source, so the bundled Opus C keeps its relaxed flags) and the opus_to_wav example. The CI build job sets -DENABLE_WERROR=ON.

-Wno-error=maybe-uninitialized is gated to GCC: it covers a GCC false positive at -O2, but Clang rejects the unknown option under -Werror.

Fix the conversions the gate surfaced (explicit casts), including read_le32, where shifting a promoted uint8_t into the sign bit was signed-overflow UB.